### PR TITLE
VP-6223: Fix alpha not contain a branch name

### DIFF
--- a/workflow-templates/module.yml
+++ b/workflow-templates/module.yml
@@ -1,4 +1,4 @@
-# v1.1.1
+# v1.1.2
 name: Module CI
 
 on:
@@ -29,8 +29,15 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
       NUGET_KEY: ${{ secrets.NUGET_KEY }}
       BLOB_SAS: ${{ secrets.BLOB_TOKEN }}
+      VERSION_SUFFIX: ""
 
     steps:
+
+      - name: Set up JDK 11 for dotnet-sonarscanner #Sonar stop accepting Java versions less than 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -49,11 +56,20 @@ jobs:
         uses: VirtoCommerce/vc-github-actions/get-image-version@master
         id: image
 
+      - name: Set release variables
+        run: |
+          echo "VERSION_SUFFIX=${{ steps.image.outputs.suffix }}" >> $GITHUB_ENV
+
+      - name: Set release-alpha for custom branch variables 
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "VERSION_SUFFIX=${{ steps.image.outputs.fullSuffix }}" >> $GITHUB_ENV
+
       - name: Add version suffix
         if: ${{ github.ref != 'refs/heads/master' }}
         uses: VirtoCommerce/vc-github-actions/add-version-suffix@master
         with:
-          versionSuffix: ${{ steps.image.outputs.suffix }}
+          versionSuffix: ${{ env.VERSION_SUFFIX }}
 
       - name: SonarCloud Begin
         uses: VirtoCommerce/vc-github-actions/sonar-scanner-begin@master

--- a/workflow-templates/module.yml
+++ b/workflow-templates/module.yml
@@ -56,14 +56,13 @@ jobs:
         uses: VirtoCommerce/vc-github-actions/get-image-version@master
         id: image
 
-      - name: Set release variables
+      - name: Set VERSION_SUFFIX variable
         run: |
-          echo "VERSION_SUFFIX=${{ steps.image.outputs.suffix }}" >> $GITHUB_ENV
-
-      - name: Set release-alpha for custom branch variables 
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          echo "VERSION_SUFFIX=${{ steps.image.outputs.fullSuffix }}" >> $GITHUB_ENV
+          if [ '${{ github.event_name }}' = 'workflow_dispatch' ]; then
+            echo "VERSION_SUFFIX=${{ steps.image.outputs.fullSuffix }}" >> $GITHUB_ENV
+          else
+            echo "VERSION_SUFFIX=${{ steps.image.outputs.suffix }}" >> $GITHUB_ENV
+          fi;
 
       - name: Add version suffix
         if: ${{ github.ref != 'refs/heads/master' }}

--- a/workflow-templates/platform.yml
+++ b/workflow-templates/platform.yml
@@ -1,4 +1,4 @@
-# v1.1.1
+# v1.1.2
 name: Platform CI
 
 # Controls when the action will run. Triggers the workflow on push or pull request
@@ -33,6 +33,7 @@ jobs:
       BLOB_SAS: ${{ secrets.BLOB_TOKEN }}
       PUBLISH_TO_DOCKER: "true"
       UPDATE_LATEST_TAG: "true"
+      VERSION_SUFFIX: ""
 
     steps:
     - name: Set variables
@@ -40,6 +41,11 @@ jobs:
       run: |
         echo "PUBLISH_TO_DOCKER=false" >> $GITHUB_ENV
         echo "UPDATE_LATEST_TAG=false" >> $GITHUB_ENV 
+
+    - name: Set up JDK 11 for dotnet-sonarscanner #Sonar stop accepting Java versions less than 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.11
 
     - uses: actions/checkout@v2
       with:
@@ -59,11 +65,20 @@ jobs:
       id: changelog
       uses: VirtoCommerce/vc-github-actions/changelog-generator@master
 
+    - name: Set release variables
+      run: |
+        echo "VERSION_SUFFIX=${{ steps.image.outputs.suffix }}" >> $GITHUB_ENV
+
+    - name: Set release-alpha for custom branch variables 
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      run: |
+        echo "VERSION_SUFFIX=${{ steps.image.outputs.fullSuffix }}" >> $GITHUB_ENV
+
     - name: Add version suffix
       if: ${{ github.ref != 'refs/heads/master' }}
       uses: VirtoCommerce/vc-github-actions/add-version-suffix@master
       with:
-        versionSuffix: ${{ steps.image.outputs.suffix }}
+        versionSuffix: ${{ env.VERSION_SUFFIX }}
 
     - name: SonarCloud Begin
       uses: VirtoCommerce/vc-github-actions/sonar-scanner-begin@master

--- a/workflow-templates/platform.yml
+++ b/workflow-templates/platform.yml
@@ -65,14 +65,13 @@ jobs:
       id: changelog
       uses: VirtoCommerce/vc-github-actions/changelog-generator@master
 
-    - name: Set release variables
+    - name: Set VERSION_SUFFIX variable
       run: |
-        echo "VERSION_SUFFIX=${{ steps.image.outputs.suffix }}" >> $GITHUB_ENV
-
-    - name: Set release-alpha for custom branch variables 
-      if: ${{ github.event_name == 'workflow_dispatch' }}
-      run: |
-        echo "VERSION_SUFFIX=${{ steps.image.outputs.fullSuffix }}" >> $GITHUB_ENV
+        if [ '${{ github.event_name }}' = 'workflow_dispatch' ]; then
+          echo "VERSION_SUFFIX=${{ steps.image.outputs.fullSuffix }}" >> $GITHUB_ENV
+        else
+          echo "VERSION_SUFFIX=${{ steps.image.outputs.suffix }}" >> $GITHUB_ENV
+        fi;
 
     - name: Add version suffix
       if: ${{ github.ref != 'refs/heads/master' }}

--- a/workflow-templates/storefront.yml
+++ b/workflow-templates/storefront.yml
@@ -1,8 +1,6 @@
-# v1.1.1
+# v1.1.2
 name: Storefront CI
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on:
   workflow_dispatch:
   push:
@@ -32,6 +30,7 @@ jobs:
       BLOB_SAS: ${{ secrets.BLOB_TOKEN }}
       PUBLISH_TO_DOCKER: "true"
       UPDATE_LATEST_TAG: "true"
+      VERSION_SUFFIX: ""
 
     steps:
     - name: Set variables
@@ -39,6 +38,11 @@ jobs:
       run: |
         echo "PUBLISH_TO_DOCKER=false" >> $GITHUB_ENV
         echo "UPDATE_LATEST_TAG=false" >> $GITHUB_ENV 
+
+    - name: Set up JDK 11 for dotnet-sonarscanner #Sonar stop accepting Java versions less than 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.11
 
     - uses: actions/checkout@v2
       with:
@@ -58,11 +62,20 @@ jobs:
       id: changelog
       uses: VirtoCommerce/vc-github-actions/changelog-generator@master
 
+    - name: Set release variables
+      run: |
+        echo "VERSION_SUFFIX=${{ steps.image.outputs.suffix }}" >> $GITHUB_ENV
+
+    - name: Set release-alpha for custom branch variables 
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      run: |
+        echo "VERSION_SUFFIX=${{ steps.image.outputs.fullSuffix }}" >> $GITHUB_ENV
+
     - name: Add version suffix
       if: ${{ github.ref != 'refs/heads/master' }}
       uses: VirtoCommerce/vc-github-actions/add-version-suffix@master
       with:
-        versionSuffix: ${{ steps.image.outputs.suffix }}
+        versionSuffix: ${{ env.VERSION_SUFFIX }}
 
     - name: SonarCloud Begin
       uses: VirtoCommerce/vc-github-actions/sonar-scanner-begin@master

--- a/workflow-templates/storefront.yml
+++ b/workflow-templates/storefront.yml
@@ -62,14 +62,13 @@ jobs:
       id: changelog
       uses: VirtoCommerce/vc-github-actions/changelog-generator@master
 
-    - name: Set release variables
+    - name: Set VERSION_SUFFIX variable
       run: |
-        echo "VERSION_SUFFIX=${{ steps.image.outputs.suffix }}" >> $GITHUB_ENV
-
-    - name: Set release-alpha for custom branch variables 
-      if: ${{ github.event_name == 'workflow_dispatch' }}
-      run: |
-        echo "VERSION_SUFFIX=${{ steps.image.outputs.fullSuffix }}" >> $GITHUB_ENV
+        if [ '${{ github.event_name }}' = 'workflow_dispatch' ]; then
+          echo "VERSION_SUFFIX=${{ steps.image.outputs.fullSuffix }}" >> $GITHUB_ENV
+        else
+          echo "VERSION_SUFFIX=${{ steps.image.outputs.suffix }}" >> $GITHUB_ENV
+        fi;
 
     - name: Add version suffix
       if: ${{ github.ref != 'refs/heads/master' }}

--- a/workflow-templates/theme.yml
+++ b/workflow-templates/theme.yml
@@ -42,14 +42,13 @@ jobs:
       uses: VirtoCommerce/vc-github-actions/get-image-version@master
       id: image
 
-    - name: Set release variables
+    - name: Set VERSION_SUFFIX variable
       run: |
-        echo "VERSION_SUFFIX=${{ steps.image.outputs.suffix }}" >> $GITHUB_ENV
-
-    - name: Set release-alpha for custom branch variables 
-      if: ${{ github.event_name == 'workflow_dispatch' }}
-      run: |
-        echo "VERSION_SUFFIX=${{ steps.image.outputs.fullSuffix }}" >> $GITHUB_ENV
+        if [ '${{ github.event_name }}' = 'workflow_dispatch' ]; then
+          echo "VERSION_SUFFIX=${{ steps.image.outputs.fullSuffix }}" >> $GITHUB_ENV
+        else
+          echo "VERSION_SUFFIX=${{ steps.image.outputs.suffix }}" >> $GITHUB_ENV
+        fi;
 
     - name: Get changelog
       id: changelog

--- a/workflow-templates/theme.yml
+++ b/workflow-templates/theme.yml
@@ -1,4 +1,4 @@
-# v1.1.1
+# v1.1.2
 name: Theme CI
 on:
   workflow_dispatch:
@@ -28,6 +28,7 @@ jobs:
       SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
       GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
       BLOB_SAS: ${{ secrets.BLOB_TOKEN }}
+      VERSION_SUFFIX: ""
 
     steps:
     - uses: actions/checkout@v2
@@ -41,6 +42,15 @@ jobs:
       uses: VirtoCommerce/vc-github-actions/get-image-version@master
       id: image
 
+    - name: Set release variables
+      run: |
+        echo "VERSION_SUFFIX=${{ steps.image.outputs.suffix }}" >> $GITHUB_ENV
+
+    - name: Set release-alpha for custom branch variables 
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      run: |
+        echo "VERSION_SUFFIX=${{ steps.image.outputs.fullSuffix }}" >> $GITHUB_ENV
+
     - name: Get changelog
       id: changelog
       uses: VirtoCommerce/vc-github-actions/changelog-generator@master
@@ -52,7 +62,7 @@ jobs:
       if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' || github.event_name == 'workflow_dispatch' }}
       uses: VirtoCommerce/vc-github-actions/build-theme@master
       with:
-        versionSuffix: ${{ steps.image.outputs.suffix }}
+        versionSuffix: ${{ env.VERSION_SUFFIX }}
 
     - name: Publish
       if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master')}}


### PR DESCRIPTION
* Fix issue alpha-version not contain a branch name when workflows run manually
* Set up JDK 11 for dotnet-sonarscanner. Sonar stop accepting Java versions less than 11