### PR TITLE
VCST-3725: Check for .deployment folder before deployment to cloud

### DIFF
--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -55,6 +55,7 @@ jobs:
       matrix: ${{ steps.deployment-matrix.outputs.matrix }}
       run-e2e: ${{ steps.run-e2e.outputs.result }}
       run-ui-tests: ${{ steps.run-ui-tests.outputs.result }}
+      deployment-folder-exists: ${{ steps.check_deployment_folder.outputs.exists }}
 
     steps:
 
@@ -91,6 +92,17 @@ jobs:
       - name: Get Artifact Version
         uses: VirtoCommerce/vc-github-actions/get-image-version@master
         id: artifact_ver
+
+      - name: Check if .deployment folder exists
+        id: check_deployment_folder
+        run: |
+          if [ -d ".deployment" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Diagnostic: .deployment folder exists."
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Diagnostic: .deployment folder does NOT exist."
+          fi
 
       - name: Set VERSION_SUFFIX variable
         run: |
@@ -294,7 +306,9 @@ jobs:
       katalonApiKey: ${{ secrets.KATALON_API_KEY }}
 
   deploy-cloud:
-    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
+    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+      && github.event_name == 'push'
+      && needs.ci.outputs.deployment-folder-exists == 'true'}}
     needs: ci
     uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.13
     with:


### PR DESCRIPTION
feat: Added a step to verify the existence of the `.deployment` folder. The result is stored in the `deployment-folder-exists` output variable, which is now used in the deployment job's conditional logic. The deployment will only proceed if the folder exists, along with the existing conditions based on the branch and event type.