### PR TITLE
VCST-4266: Add a date condition for the build runs

### DIFF
--- a/.github/workflows/collect-deprecation-warnings.yml
+++ b/.github/workflows/collect-deprecation-warnings.yml
@@ -65,7 +65,7 @@ jobs:
               [array]$runs = gh run list -R VirtoCommerce/$repo --limit ${{ env.NUMBER_OF_RUNS}} --json $fields | ConvertFrom-Json
               foreach ($run in $runs) {
                   $runId = "$($run.databaseId)"
-                  $deprecationWarnings = gh run view $runId -R VirtoCommerce/$repo | Select-String -Pattern "deprecated"
+                  $deprecationWarnings = gh run view $runId -R VirtoCommerce/$repo | Select-String -Pattern 'deprecated', 'obsolete'
                   if ($deprecationWarnings) {
                       foreach ($warning in $deprecationWarnings) {
                           $skip = $false

--- a/.github/workflows/collect-deprecation-warnings.yml
+++ b/.github/workflows/collect-deprecation-warnings.yml
@@ -68,7 +68,9 @@ jobs:
                   continue
               }
               [array]$runs = gh run list -R VirtoCommerce/$repo --limit ${{ env.NUMBER_OF_RUNS}} --json $fields | ConvertFrom-Json
+              echo "Runs before filtering: $runs"
               $runs = $runs | Where-Object { $_.createdAt -gt $timeThreshold }
+              echo "Runs after filtering: $runs"
               foreach ($run in $runs) {
                   $runId = "$($run.databaseId)"
                   $deprecationWarnings = gh run view $runId -R VirtoCommerce/$repo | Select-String -Pattern 'deprecated', 'obsolete'

--- a/.github/workflows/collect-deprecation-warnings.yml
+++ b/.github/workflows/collect-deprecation-warnings.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: string
         default: 'all'
+      dateThreshold:
+        description: 'Date threshold for checking deprecation warnings in days'
+        required: false
+        type: string
+        default: '30'
     
   schedule:
     - cron: '0 0 15 * *' # monthly on the 15th day at 00:00
@@ -50,11 +55,11 @@ jobs:
           } else {
             [array]$repos = "${{ env.REPOS }}".Split(',')
           }
-          $fields = 'databaseId,name,conclusion'
+          $fields = 'databaseId,name,conclusion,createdAt'
           $result = @()
           $skipValues = @('set-output', 'angular@1.8.3', 'angular-cookies@1.8.3', 'angular-resource@1.8.3', 'angular-translate-loader-url@2.19.1', 'angular-translate-storage-cookie@2.15.2', 'glob@7.1.7', 'har-validator@5.1.5', 'inflight@1.0.6', 'request@2.88.2', 'rimraf@2.7.1', 'angular-translate-storage-local@2.19.1')
-          # $skipValues = @('qwerty')
-
+          $timeThreshold = (Get-Date).AddDays(-${{ github.event.inputs.dateThreshold || 30 }})
+          $deprecationWarnings = @()
           foreach ($repo in $repos) {
               echo "Checking repo: $repo"
               $testAccess = gh api "repos/VirtoCommerce/$repo" --jq '.id'
@@ -63,6 +68,7 @@ jobs:
                   continue
               }
               [array]$runs = gh run list -R VirtoCommerce/$repo --limit ${{ env.NUMBER_OF_RUNS}} --json $fields | ConvertFrom-Json
+              $runs = $runs | Where-Object { $_.createdAt -gt $timeThreshold }
               foreach ($run in $runs) {
                   $runId = "$($run.databaseId)"
                   $deprecationWarnings = gh run view $runId -R VirtoCommerce/$repo | Select-String -Pattern 'deprecated', 'obsolete'

--- a/.github/workflows/collect-deprecation-warnings.yml
+++ b/.github/workflows/collect-deprecation-warnings.yml
@@ -114,22 +114,22 @@ jobs:
         run: |
           cat $env:RUNNER_TEMP/deprecation-warnings.json
 
-      - name: Upload deprecation warnings list
-        if: ${{ steps.collect-deprecation-warnings.outputs.result == 'true' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: deprecation-warnings
-          path: ${{ runner.temp }}/deprecation-warnings.json
-          retention-days: 30
-        continue-on-error: true
+      # - name: Upload deprecation warnings list
+      #   if: ${{ steps.collect-deprecation-warnings.outputs.result == 'true' }}
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: deprecation-warnings
+      #     path: ${{ runner.temp }}/deprecation-warnings.json
+      #     retention-days: 30
+      #   continue-on-error: true
 
-      - name: Teams notification
-        if: ${{ steps.collect-deprecation-warnings.outputs.result == 'true' }}
-        uses: VirtoCommerce/vc-github-actions/publish-teams-webhook-notification@master
-        with:
-          teamsWebhookUrl: ${{ env.TEAMS_WEBHOOK_URL }}
-          mentions: '@(@{id = "859369bc-81d3-498d-a3a8-ceba4dd6c8a4"; name = "Andrew.Kubyshkin" })'
-          title: 'New deprecation warning(s) found'
-          workflowName: ${{ github.workflow }}
-          buildId: ${{ github.run_id }}
-          githubRepo: '${{ github.repository }}'
+      # - name: Teams notification
+      #   if: ${{ steps.collect-deprecation-warnings.outputs.result == 'true' }}
+      #   uses: VirtoCommerce/vc-github-actions/publish-teams-webhook-notification@master
+      #   with:
+      #     teamsWebhookUrl: ${{ env.TEAMS_WEBHOOK_URL }}
+      #     mentions: '@(@{id = "859369bc-81d3-498d-a3a8-ceba4dd6c8a4"; name = "Andrew.Kubyshkin" })'
+      #     title: 'New deprecation warning(s) found'
+      #     workflowName: ${{ github.workflow }}
+      #     buildId: ${{ github.run_id }}
+      #     githubRepo: '${{ github.repository }}'

--- a/.github/workflows/collect-deprecation-warnings.yml
+++ b/.github/workflows/collect-deprecation-warnings.yml
@@ -2,10 +2,11 @@
 # https://virtocommerce.atlassian.net/browse/VCST-923
 
 # =======================================================================================
-# The workflow collects deprecation warnings from repos in the VirtoCommerce organization.
+# The workflow collects deprecation and obsolete warnings from repos in the VirtoCommerce organization.
 # The list of repos can be specified in the workflow inputs.
-# The number of runs to check for deprecation warnings in each repo can be specified in the workflow inputs.
-# The workflow will collect deprecation warnings from the last ${{ inputs.numberOfRuns }} runs for each repo.
+# The number of runs to check for deprecation and obsolete warnings in each repo can be specified in the workflow inputs.
+# The date threshold for checking deprecation and obsolete warnings in days can be specified in the workflow inputs. The runs older than the date threshold will be skipped.
+# The workflow will collect deprecation and obsolete warnings from the last ${{ inputs.numberOfRuns }} runs for each repo.
 # The workflow will skip repos that are not in the list of repos specified in the workflow inputs.
 # =======================================================================================
 name: Collect deprecation warnings
@@ -14,17 +15,17 @@ on:
   workflow_dispatch:
     inputs:
       numberOfRuns:
-        description: 'Number of runs to check for deprecation warnings in each repo'
+        description: 'Number of runs to check for deprecation and obsolete warnings in each repo'
         required: false
         type: number
         default: 5
       repos:
-        description: 'Repos to check for deprecation warnings. Allowed values: "all" or comma separated list of repos'
+        description: 'Repos to check for deprecation and obsolete warnings. Allowed values: "all" or comma separated list of repos'
         required: false
         type: string
         default: 'all'
       dateThreshold:
-        description: 'Date threshold for checking deprecation warnings in days'
+        description: 'Date threshold for checking deprecation and obsolete warnings in days'
         required: false
         type: string
         default: '30'
@@ -114,22 +115,22 @@ jobs:
         run: |
           cat $env:RUNNER_TEMP/deprecation-warnings.json
 
-      # - name: Upload deprecation warnings list
-      #   if: ${{ steps.collect-deprecation-warnings.outputs.result == 'true' }}
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: deprecation-warnings
-      #     path: ${{ runner.temp }}/deprecation-warnings.json
-      #     retention-days: 30
-      #   continue-on-error: true
+      - name: Upload deprecation warnings list
+        if: ${{ steps.collect-deprecation-warnings.outputs.result == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: deprecation-warnings
+          path: ${{ runner.temp }}/deprecation-warnings.json
+          retention-days: 30
+        continue-on-error: true
 
-      # - name: Teams notification
-      #   if: ${{ steps.collect-deprecation-warnings.outputs.result == 'true' }}
-      #   uses: VirtoCommerce/vc-github-actions/publish-teams-webhook-notification@master
-      #   with:
-      #     teamsWebhookUrl: ${{ env.TEAMS_WEBHOOK_URL }}
-      #     mentions: '@(@{id = "859369bc-81d3-498d-a3a8-ceba4dd6c8a4"; name = "Andrew.Kubyshkin" })'
-      #     title: 'New deprecation warning(s) found'
-      #     workflowName: ${{ github.workflow }}
-      #     buildId: ${{ github.run_id }}
-      #     githubRepo: '${{ github.repository }}'
+      - name: Teams notification
+        if: ${{ steps.collect-deprecation-warnings.outputs.result == 'true' }}
+        uses: VirtoCommerce/vc-github-actions/publish-teams-webhook-notification@master
+        with:
+          teamsWebhookUrl: ${{ env.TEAMS_WEBHOOK_URL }}
+          mentions: '@(@{id = "859369bc-81d3-498d-a3a8-ceba4dd6c8a4"; name = "Andrew.Kubyshkin" })'
+          title: 'New deprecation warning(s) found'
+          workflowName: ${{ github.workflow }}
+          buildId: ${{ github.run_id }}
+          githubRepo: '${{ github.repository }}'

--- a/.github/workflows/collect-deprecation-warnings.yml
+++ b/.github/workflows/collect-deprecation-warnings.yml
@@ -68,9 +68,11 @@ jobs:
                   continue
               }
               [array]$runs = gh run list -R VirtoCommerce/$repo --limit ${{ env.NUMBER_OF_RUNS}} --json $fields | ConvertFrom-Json
-              echo "Runs before filtering: $runs"
+              echo "Runs before filtering:"
+              $runs
               $runs = $runs | Where-Object { $_.createdAt -gt $timeThreshold }
-              echo "Runs after filtering: $runs"
+              echo "Runs after filtering:"
+              $runs
               foreach ($run in $runs) {
                   $runId = "$($run.databaseId)"
                   $deprecationWarnings = gh run view $runId -R VirtoCommerce/$repo | Select-String -Pattern 'deprecated', 'obsolete'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds date-based filtering and expands scanning to obsolete warnings in the deprecation warnings workflow.
> 
> - **GitHub Actions workflow `collect-deprecation-warnings.yml`**:
>   - Inputs: add `dateThreshold` (days); update descriptions to cover deprecation and obsolete warnings.
>   - Run retrieval: include `createdAt` field; compute time threshold and filter runs newer than it.
>   - Scanning: extend pattern to match both `deprecated` and `obsolete`.
>   - Diagnostics: add pre/post filtering logs for runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55eaf73a672dcc3bdb79878120f27e6340a0c8ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->