### PR TITLE
VCST-4203: Allow passing required modules list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: VC build
 
 on:

--- a/.github/workflows/collect-deprecation-warnings.yml
+++ b/.github/workflows/collect-deprecation-warnings.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 
 # =======================================================================================
 # The workflow collects deprecation and obsolete warnings from repos in the VirtoCommerce organization.

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: VC cloud deployment
 
 on:

--- a/.github/workflows/deploy-module-workflows.yml
+++ b/.github/workflows/deploy-module-workflows.yml
@@ -7,7 +7,7 @@ on:
         description: 'Version to deploy'
         required: true
         type: string
-        default: 'v3.800.19'
+        default: 'v3.800.20'
 
 jobs:
 

--- a/.github/workflows/deploy-platform-workflows.yml
+++ b/.github/workflows/deploy-platform-workflows.yml
@@ -7,7 +7,7 @@ on:
         description: 'Version to deploy'
         required: true
         type: string
-        default: 'v3.800.19'
+        default: 'v3.800.20'
 
 jobs:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: VC deployment
 
 on:

--- a/.github/workflows/docker-image-vulnerability-process.yml
+++ b/.github/workflows/docker-image-vulnerability-process.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: Docker image vulnerability process
 
 on:

--- a/.github/workflows/e2e-autotests.yml
+++ b/.github/workflows/e2e-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: Common E2E tests
 
 on:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,6 +35,11 @@ on:
         required: false
         type: string
         default: ''
+      customModuleListUrl:
+        description: 'Custom module list url'
+        required: false
+        type: string
+        default: ''
       customModuleUrl:
         description: 'Custom module Module url'
         required: false
@@ -81,7 +86,7 @@ jobs:
         path: ${{ env.KATALON_PATH }}
 
     - name: Docker Env
-      uses: VirtoCommerce/vc-github-actions/docker-env@master
+      uses: VirtoCommerce/vc-github-actions/docker-env@VCST-4203 #master
       with:
         githubUser: ${{ env.GITHUB_ACTOR }}
         githubToken: ${{ env.GITHUB_TOKEN }}
@@ -92,6 +97,7 @@ jobs:
         installCustomModule: ${{ inputs.installCustomModule }}
         customModuleId: ${{ inputs.customModuleId }}
         customModuleUrl: ${{ inputs.customModuleUrl }}
+        customModuleListUrl: ${{ inputs.customModuleListUrl }}
         envDir: '${{ github.workspace }}'
         
     - name: Setup Java

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,8 +35,8 @@ on:
         required: false
         type: string
         default: ''
-      customModuleListUrl:
-        description: 'Custom module list url'
+      requiredModulesListUrl:
+        description: 'The URL of the JSON file with the required modules list'
         required: false
         type: string
         default: ''
@@ -97,7 +97,7 @@ jobs:
         installCustomModule: ${{ inputs.installCustomModule }}
         customModuleId: ${{ inputs.customModuleId }}
         customModuleUrl: ${{ inputs.customModuleUrl }}
-        customModuleListUrl: ${{ inputs.customModuleListUrl }}
+        requiredModulesListUrl: ${{ inputs.requiredModulesListUrl }}
         envDir: '${{ github.workspace }}'
         
     - name: Setup Java

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: Common katalon tests
 
 on:
@@ -64,7 +64,7 @@ on:
 
 jobs:
   e2e-tests:
-    runs-on: ubuntu-22.04 # katalon action runs correctly on ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     env:
       GITHUB_TOKEN: ${{ secrets.envPAT }}
@@ -86,7 +86,7 @@ jobs:
         path: ${{ env.KATALON_PATH }}
 
     - name: Docker Env
-      uses: VirtoCommerce/vc-github-actions/docker-env@VCST-4203 #master
+      uses: VirtoCommerce/vc-github-actions/docker-env@master
       with:
         githubUser: ${{ env.GITHUB_ACTOR }}
         githubToken: ${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/get-metadata.yml
+++ b/.github/workflows/get-metadata.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: Get metadata
 
 on:

--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: Increment version
 
 on:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: VC Publish docker
 
 on:

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: VC Publish Github release and Nuget package
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: Release workflow
 
 on:

--- a/.github/workflows/test-and-sonar.yml
+++ b/.github/workflows/test-and-sonar.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: VC unit test and sonar scan
 
 on:

--- a/.github/workflows/ui-autotests.yml
+++ b/.github/workflows/ui-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: Common UI tests
 
 on:

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: Module CI
 
 on:
@@ -278,7 +278,7 @@ jobs:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
     needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.19
+    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.20
     with:
       installModules: 'false'
       installCustomModule: 'true'
@@ -295,7 +295,7 @@ jobs:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
     needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/e2e.yml@v3.800.19
+    uses: VirtoCommerce/.github/.github/workflows/e2e.yml@v3.800.20
     with:
       katalonRepo: 'VirtoCommerce/vc-quality-gate-katalon'
       katalonRepoBranch: 'dev'
@@ -315,7 +315,7 @@ jobs:
       && github.event_name == 'push'
       && needs.ci.outputs.deployment-folder-exists == 'true'}}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.19
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.20
     with:
       releaseSource: module
       moduleId: ${{ needs.ci.outputs.moduleId }}

--- a/workflow-templates/module-deploy.yml
+++ b/workflow-templates/module-deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: Module deployment
 on:
   workflow_dispatch:

--- a/workflow-templates/module-release-hotfix.yml
+++ b/workflow-templates/module-release-hotfix.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: Release hotfix
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.19
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.20
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.19    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.20    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -46,7 +46,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.19
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.20
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/workflow-templates/platform-ci.yml
+++ b/workflow-templates/platform-ci.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: Platform CI
 
 on:
@@ -316,7 +316,7 @@ jobs:
     needs: 'ci'
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.19  
+    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.20  
     with:
       installModules: 'true'
       installCustomModule: 'false'
@@ -331,7 +331,7 @@ jobs:
     needs: 'ci'
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/e2e.yml@v3.800.19
+    uses: VirtoCommerce/.github/.github/workflows/e2e.yml@v3.800.20
     with:
       katalonRepo: 'VirtoCommerce/vc-quality-gate-katalon'
       katalonRepoBranch: 'dev'
@@ -347,7 +347,7 @@ jobs:
   deploy-cloud:
     if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.19    
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.20    
     with:
       releaseSource: platform
       platformVer: ${{ needs.ci.outputs.version }}
@@ -374,7 +374,7 @@ jobs:
   trivy-scan:
     if: ${{ github.ref == 'refs/heads/dev' && github.event_name == 'push' }}
     needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.19  
+    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.20  
     with:
       assigneeAccountId: '621c47c0302c6b006af0a1cd'
       assigneeEmailAddress: 'andrew.kubyshkin@virtoworks.com'

--- a/workflow-templates/platform-regression-pr.yml
+++ b/workflow-templates/platform-regression-pr.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: Platform Regression PR
 
 on: 

--- a/workflow-templates/platform-release-hotfix.yml
+++ b/workflow-templates/platform-release-hotfix.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: Release hotfix
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.19    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.20    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.19    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.20    
     with:
       uploadPackage: 'true'
       uploadDocker: 'true'
@@ -47,7 +47,7 @@ jobs:
   publish-docker:
     needs:
       [build, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.19    
+    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.20    
     with:
       fullKey: ${{ needs.build.outputs.dockerFullKey }}
       shortKey: '${{ needs.build.outputs.dockerShortKey }}-'
@@ -61,7 +61,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.19    
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.20    
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/workflow-templates/publish-nugets.yml
+++ b/workflow-templates/publish-nugets.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: Publish nuget
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.19    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.20    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.19    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.20    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -29,7 +29,7 @@ jobs:
   publish-nuget:
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.19
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.20
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: Release
 
 on:
@@ -7,6 +7,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.19    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.20    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}

--- a/workflow-templates/storefront-ci.yml
+++ b/workflow-templates/storefront-ci.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: Storefront CI
 
 on:

--- a/workflow-templates/theme-ci.yml
+++ b/workflow-templates/theme-ci.yml
@@ -225,7 +225,7 @@ jobs:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
       (github.base_ref == 'dev') && (github.event_name == 'pull_request') || 
       (github.event_name == 'workflow_dispatch') }}
-    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.19  
+    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.20  
     with:
       installModules: 'true'
       installCustomModule: 'false'

--- a/workflow-templates/theme-deploy.yml
+++ b/workflow-templates/theme-deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.19
-# https://virtocommerce.atlassian.net/browse/VCST-923
+# v3.800.20
+# https://virtocommerce.atlassian.net/browse/VCST-4203
 name: Theme deployment
 on:
   workflow_dispatch:


### PR DESCRIPTION
Add an option to pass a list of packages required for installation in the environment executing tests, and add log grouping for clearer logs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates all reusable workflows to v3.800.20 and adds a `requiredModulesListUrl` input to Katalon E2E setup, wiring it into the Docker env action.
> 
> - **CI/CD Workflows**:
>   - Bump version references and headers from `v3.800.19` to `v3.800.20` across reusable workflows and templates (build, test/sonar, publish, deploy, platform/module/storefront/theme pipelines).
> - **E2E (Katalon) Enhancements**:
>   - Add `requiredModulesListUrl` input in `.github/workflows/e2e.yml` and pass it to `docker-env` to supply required modules list during test environment setup.
>   - Minor cleanup in `e2e.yml` runner configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a22af0e9610cab3fb77d9d78b905bb37f128a17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->