### PR TITLE
VCST-4086: Add an option to use a custom packages.json for backend when running e2e autotests

### DIFF
--- a/.github/workflows/e2e-autotests.yml
+++ b/.github/workflows/e2e-autotests.yml
@@ -119,11 +119,13 @@ jobs:
       uses: VirtoCommerce/vc-github-actions/docker-env-full@VCST-4086 #master
       with:
         frontendZipUrl: ${{ inputs.frontendZipUrl }}
-        installModules: 'true'
-        installCustomModule: 'false'
-        platformDockerTag: 'dev-linux-latest'
+        installModules: ${{ inputs.installModules }} #'true'
+        installCustomModule: ${{ inputs.installCustomModule }} #'false'
+        platformDockerTag: ${{ inputs.platformDockerTag }} #'dev-linux-latest'
         testSecretEnvFile: ${{ secrets.testSecretEnvFile }}
         customPackagesJsonUrl: ${{ inputs.customPackagesJsonUrl }}
+        customModuleId: ${{ inputs.customModuleId }}
+        customModuleUrl: ${{ inputs.customModuleUrl }}
     
     - name: Run E2E Tests
       uses: VirtoCommerce/vc-github-actions/run-e2e-tests@master

--- a/.github/workflows/e2e-autotests.yml
+++ b/.github/workflows/e2e-autotests.yml
@@ -116,11 +116,11 @@ jobs:
       uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
     - name: Docker Env Full
-      uses: VirtoCommerce/vc-github-actions/docker-env-full@VCST-4086 #master
+      uses: VirtoCommerce/vc-github-actions/docker-env-full@master
       with:
         frontendZipUrl: ${{ inputs.frontendZipUrl }}
-        installModules: ${{ inputs.installModules }} #'true'
-        installCustomModule: ${{ inputs.installCustomModule }} #'false'
+        installModules: ${{ inputs.installModules }}
+        installCustomModule: ${{ inputs.installCustomModule }}
         platformDockerTag: ${{ inputs.platformDockerTag }} #'dev-linux-latest'
         testSecretEnvFile: ${{ secrets.testSecretEnvFile }}
         customPackagesJsonUrl: ${{ inputs.customPackagesJsonUrl }}

--- a/.github/workflows/e2e-autotests.yml
+++ b/.github/workflows/e2e-autotests.yml
@@ -121,7 +121,7 @@ jobs:
         frontendZipUrl: ${{ inputs.frontendZipUrl }}
         installModules: ${{ inputs.installModules }}
         installCustomModule: ${{ inputs.installCustomModule }}
-        platformDockerTag: ${{ inputs.platformDockerTag }} #'dev-linux-latest'
+        platformDockerTag: 'dev-linux-latest'
         testSecretEnvFile: ${{ secrets.testSecretEnvFile }}
         customPackagesJsonUrl: ${{ inputs.customPackagesJsonUrl }}
         customModuleId: ${{ inputs.customModuleId }}

--- a/.github/workflows/e2e-autotests.yml
+++ b/.github/workflows/e2e-autotests.yml
@@ -44,6 +44,11 @@ on:
         required: false
         type: string
         default: ''
+      customPackagesJsonUrl:
+        description: 'Custom packages.json url'
+        required: false
+        type: string
+        default: ''
       frontendZipUrl:
         required: false
         type: string
@@ -111,13 +116,14 @@ jobs:
       uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
     - name: Docker Env Full
-      uses: VirtoCommerce/vc-github-actions/docker-env-full@master
+      uses: VirtoCommerce/vc-github-actions/docker-env-full@VCST-4086 #master
       with:
         frontendZipUrl: ${{ inputs.frontendZipUrl }}
         installModules: 'true'
         installCustomModule: 'false'
         platformDockerTag: 'dev-linux-latest'
         testSecretEnvFile: ${{ secrets.testSecretEnvFile }}
+        customPackagesJsonUrl: ${{ inputs.customPackagesJsonUrl }}
     
     - name: Run E2E Tests
       uses: VirtoCommerce/vc-github-actions/run-e2e-tests@master


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `customPackagesJsonUrl` input and forwards custom module params; makes module install steps configurable in `e2e-autotests.yml`.
> 
> - **GitHub Actions (`.github/workflows/e2e-autotests.yml`)**:
>   - Add new input `customPackagesJsonUrl` and pass it to `docker-env-full`.
>   - Make `installModules` and `installCustomModule` configurable via inputs (no longer hardcoded).
>   - Forward `customModuleId` and `customModuleUrl` inputs to `docker-env-full`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2270d978585836cb30cc6430fdb71c466fde1d2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->