### PR TITLE
VCST-4487: Fix Sonar issue to not use user-controlled data directly as the parameter 'branchName' in module-ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
-# v3.800.23
-# https://virtocommerce.atlassian.net/browse/VCST-3056
+# v3.800.24
+# https://virtocommerce.atlassian.net/browse/VCST-4487
 name: VC build
 
 on:

--- a/.github/workflows/collect-deprecation-warnings.yml
+++ b/.github/workflows/collect-deprecation-warnings.yml
@@ -1,5 +1,5 @@
-# v3.800.23
-# https://virtocommerce.atlassian.net/browse/VCST-3056
+# v3.800.24
+# https://virtocommerce.atlassian.net/browse/VCST-4487
 
 # =======================================================================================
 # The workflow collects deprecation and obsolete warnings from repos in the VirtoCommerce organization.

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -1,5 +1,5 @@
-# v3.800.23
-# https://virtocommerce.atlassian.net/browse/VCST-3056
+# v3.800.24
+# https://virtocommerce.atlassian.net/browse/VCST-4487
 name: VC cloud deployment
 
 on:

--- a/.github/workflows/deploy-module-workflows.yml
+++ b/.github/workflows/deploy-module-workflows.yml
@@ -7,7 +7,7 @@ on:
         description: 'Version to deploy'
         required: true
         type: string
-        default: 'v3.800.23'
+        default: 'v3.800.24'
 
 jobs:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.23
-# https://virtocommerce.atlassian.net/browse/VCST-3056
+# v3.800.24
+# https://virtocommerce.atlassian.net/browse/VCST-4487
 name: VC deployment
 
 on:

--- a/.github/workflows/docker-image-vulnerability-process.yml
+++ b/.github/workflows/docker-image-vulnerability-process.yml
@@ -1,5 +1,5 @@
-# v3.800.23
-# https://virtocommerce.atlassian.net/browse/VCST-3056
+# v3.800.24
+# https://virtocommerce.atlassian.net/browse/VCST-4487
 name: Docker image vulnerability process
 
 on:

--- a/.github/workflows/e2e-autotests.yml
+++ b/.github/workflows/e2e-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.23
-# https://virtocommerce.atlassian.net/browse/VCST-3056
+# v3.800.24
+# https://virtocommerce.atlassian.net/browse/VCST-4487
 name: Common E2E tests
 
 on:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,5 @@
-# v3.800.23
-# https://virtocommerce.atlassian.net/browse/VCST-3056
+# v3.800.24
+# https://virtocommerce.atlassian.net/browse/VCST-4487
 name: Common katalon tests
 
 on:

--- a/.github/workflows/get-metadata.yml
+++ b/.github/workflows/get-metadata.yml
@@ -1,5 +1,5 @@
-# v3.800.23
-# https://virtocommerce.atlassian.net/browse/VCST-3056
+# v3.800.24
+# https://virtocommerce.atlassian.net/browse/VCST-4487
 name: Get metadata
 
 on:

--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -1,5 +1,5 @@
-# v3.800.23
-# https://virtocommerce.atlassian.net/browse/VCST-3056
+# v3.800.24
+# https://virtocommerce.atlassian.net/browse/VCST-4487
 name: Increment version
 
 on:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,5 +1,5 @@
-# v3.800.23
-# https://virtocommerce.atlassian.net/browse/VCST-3056
+# v3.800.24
+# https://virtocommerce.atlassian.net/browse/VCST-4487
 name: VC Publish docker
 
 on:

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -1,5 +1,5 @@
-# v3.800.23
-# https://virtocommerce.atlassian.net/browse/VCST-3056
+# v3.800.24
+# https://virtocommerce.atlassian.net/browse/VCST-4487
 name: VC Publish Github release and Nuget package
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-# v3.800.23
-# https://virtocommerce.atlassian.net/browse/VCST-3056
+# v3.800.24
+# https://virtocommerce.atlassian.net/browse/VCST-4487
 name: Release workflow
 
 on:

--- a/.github/workflows/test-and-sonar.yml
+++ b/.github/workflows/test-and-sonar.yml
@@ -1,5 +1,5 @@
-# v3.800.23
-# https://virtocommerce.atlassian.net/browse/VCST-3056
+# v3.800.24
+# https://virtocommerce.atlassian.net/browse/VCST-4487
 name: VC unit test and sonar scan
 
 on:

--- a/.github/workflows/ui-autotests.yml
+++ b/.github/workflows/ui-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.23
-# https://virtocommerce.atlassian.net/browse/VCST-3056
+# v3.800.24
+# https://virtocommerce.atlassian.net/browse/VCST-4487
 name: Common UI tests
 
 on:

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -161,7 +161,7 @@ jobs:
           BRANCH_NAME: ${{ github.head_ref }}
         run: |
           # Keep only alphanumeric, hyphens, underscores, and forward slashes and limit length to 255 characters.
-          SANITIZED_BRANCH=$(echo "$BRANCH_NAME" | sed 's/[^-a-zA-Z0-9_/]//g' | cut -c1-255)
+          SANITIZED_BRANCH=$(printf '%s\n' "$BRANCH_NAME" | sed 's/[^-a-zA-Z0-9_/]//g' | cut -c1-255)
           if [ -z "$SANITIZED_BRANCH" ]; then
             echo "branch name is empty"
             exit 1

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -1,5 +1,5 @@
-# v3.800.23
-# https://virtocommerce.atlassian.net/browse/VCST-3056
+# v3.800.24
+# https://virtocommerce.atlassian.net/browse/VCST-4487
 name: Module CI
 
 on:
@@ -324,7 +324,7 @@ jobs:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
     needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.23
+    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.24
     with:
       installModules: 'false'
       installCustomModule: 'true'
@@ -342,7 +342,7 @@ jobs:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
     needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/e2e.yml@v3.800.23
+    uses: VirtoCommerce/.github/.github/workflows/e2e.yml@v3.800.24
     with:
       katalonRepo: 'VirtoCommerce/vc-quality-gate-katalon'
       katalonRepoBranch: 'dev'
@@ -363,7 +363,7 @@ jobs:
       && github.event_name == 'push'
       && needs.ci.outputs.deployment-folder-exists == 'true'}}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.23
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.24
     with:
       releaseSource: module
       moduleId: ${{ needs.ci.outputs.moduleId }}

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -157,9 +157,11 @@ jobs:
       - name: Sanitize branch name
         if: ${{ github.event_name == 'pull_request' }}
         id: sanitize_branch
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
         run: |
           # Keep only alphanumeric, hyphens, underscores, and forward slashes and limit length to 255 characters.
-          SANITIZED_BRANCH=$(echo "${{ github.head_ref }}" | sed 's/[^-a-zA-Z0-9_/]//g' | cut -c1-255)
+          SANITIZED_BRANCH=$(echo "$BRANCH_NAME" | sed 's/[^-a-zA-Z0-9_/]//g' | cut -c1-255)
           if [ -z "$SANITIZED_BRANCH" ]; then
             echo "branch name is empty"
             exit 1

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -159,11 +159,16 @@ jobs:
         id: sanitize_branch
         run: |
           # Keep only alphanumeric, hyphens, underscores, and forward slashes and limit length to 255 characters.
-          SANITIZED_BRANCH=$(echo "${{ github.head_ref }}" | sed 's/[^a-zA-Z0-9_\/-]//g' | cut -c1-255)
-          echo "branchName=$SANITIZED_BRANCH" >> $GITHUB_OUTPUT
+          SANITIZED_BRANCH=$(echo "${{ github.head_ref }}" | sed 's/[^-a-zA-Z0-9_/]//g' | cut -c1-255)
+          if [ -z "$SANITIZED_BRANCH" ]; then
+            echo "branch name is empty"
+            exit 1
+          else
+            echo "branchName=$SANITIZED_BRANCH" >> $GITHUB_OUTPUT
+          fi
 
       - name: Add Jira link
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' && steps.sanitize_branch.outcome == 'success' }}
         uses: VirtoCommerce/vc-github-actions/publish-jira-link@master
         with:
           branchName: ${{ steps.sanitize_branch.outputs.branchName }}

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -154,11 +154,19 @@ jobs:
           blobSAS: ${{ secrets.BLOB_TOKEN }}
           blobUrl: ${{ vars.BLOB_URL }}
 
+      - name: Sanitize branch name
+        if: ${{ github.event_name == 'pull_request' }}
+        id: sanitize_branch
+        run: |
+          # Keep only alphanumeric, hyphens, underscores, and forward slashes and limit length to 255 characters.
+          SANITIZED_BRANCH=$(echo "${{ github.head_ref }}" | sed 's/[^a-zA-Z0-9_\/-]//g' | cut -c1-255)
+          echo "branchName=$SANITIZED_BRANCH" >> $GITHUB_OUTPUT
+
       - name: Add Jira link
         if: ${{ github.event_name == 'pull_request' }}
         uses: VirtoCommerce/vc-github-actions/publish-jira-link@master
         with:
-          branchName: ${{ github.head_ref }}
+          branchName: ${{ steps.sanitize_branch.outputs.branchName }}
           repoOrg: ${{ github.repository_owner }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -168,7 +168,7 @@ jobs:
           fi
 
       - name: Add Jira link
-        if: ${{ github.event_name == 'pull_request' && steps.sanitize_branch.outcome == 'success' }}
+        if: ${{ github.event_name == 'pull_request' }}
         uses: VirtoCommerce/vc-github-actions/publish-jira-link@master
         with:
           branchName: ${{ steps.sanitize_branch.outputs.branchName }}

--- a/workflow-templates/module-deploy.yml
+++ b/workflow-templates/module-deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.23
-# https://virtocommerce.atlassian.net/browse/VCST-3056
+# v3.800.24
+# https://virtocommerce.atlassian.net/browse/VCST-4487
 name: Module deployment
 on:
   workflow_dispatch:

--- a/workflow-templates/module-release-hotfix.yml
+++ b/workflow-templates/module-release-hotfix.yml
@@ -1,5 +1,5 @@
-# v3.800.23
-# https://virtocommerce.atlassian.net/browse/VCST-3056
+# v3.800.24
+# https://virtocommerce.atlassian.net/browse/VCST-4487
 name: Release hotfix
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.23
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.24
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.23    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.24    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -46,7 +46,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.23
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.24
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/workflow-templates/publish-nugets.yml
+++ b/workflow-templates/publish-nugets.yml
@@ -1,5 +1,5 @@
-# v3.800.23
-# https://virtocommerce.atlassian.net/browse/VCST-3056
+# v3.800.24
+# https://virtocommerce.atlassian.net/browse/VCST-4487
 name: Publish nuget
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.23    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.24    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.23    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.24    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -29,7 +29,7 @@ jobs:
   publish-nuget:
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.23
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.24
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -1,5 +1,5 @@
-# v3.800.23
-# https://virtocommerce.atlassian.net/browse/VCST-3056
+# v3.800.24
+# https://virtocommerce.atlassian.net/browse/VCST-4487
 name: Release
 
 on:
@@ -7,6 +7,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.23    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.24    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates GitHub workflows and templates to v3.800.24 and hardens `module-ci`.
> 
> - Adds a "Sanitize branch name" step in `workflow-templates/module-ci.yml` and uses the sanitized value when calling `publish-jira-link` (prevents passing raw `github.head_ref`)
> - Bumps all reusable workflow references and headers from `v3.800.23` to `v3.800.24` across `.github/workflows/*` and `workflow-templates/*`
> - Updates `Deploy Module workflows` default version to `v3.800.24`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 904a87c64a1f62a51ec3e083d63f3afff9eca20e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->