### PR TITLE
VCST-4391: Add an option to pass required modules list for ui-autotests

### DIFF
--- a/.github/workflows/e2e-autotests.yml
+++ b/.github/workflows/e2e-autotests.yml
@@ -68,11 +68,6 @@ on:
         required: false
         type: string
         default: 'local-latest'
-      requiredModulesListUrl:
-        description: 'The URL of the JSON file with the required modules list'
-        required: false
-        type: string
-        default: ''
       runTests:
         description: 'Run tests'
         required: false
@@ -125,17 +120,16 @@ jobs:
     - name: Docker Env Full
       uses: VirtoCommerce/vc-github-actions/docker-env-full@master
       with:
-        customPackagesJsonUrl: ${{ inputs.customPackagesJsonUrl }}
-        customModuleId: ${{ inputs.customModuleId }}
-        customModuleUrl: ${{ inputs.customModuleUrl }}
         frontendZipUrl: ${{ inputs.frontendZipUrl }}
         installModules: ${{ inputs.installModules }}
         installCustomModule: ${{ inputs.installCustomModule }}
         platformDockerTag: ${{ inputs.platformDockerTag }} #'dev-linux-latest'
-        requiredModulesListUrl: ${{ inputs.requiredModulesListUrl }}
-        sendgridApiKey: ${{ secrets.sendgridApiKey }}
         testSecretEnvFile: ${{ secrets.testSecretEnvFile }}
-        
+        customPackagesJsonUrl: ${{ inputs.customPackagesJsonUrl }}
+        customModuleId: ${{ inputs.customModuleId }}
+        customModuleUrl: ${{ inputs.customModuleUrl }}
+        sendgridApiKey: ${{ secrets.sendgridApiKey }}
+    
     - name: Run E2E Tests
       uses: VirtoCommerce/vc-github-actions/run-e2e-tests@master
       with:

--- a/.github/workflows/e2e-autotests.yml
+++ b/.github/workflows/e2e-autotests.yml
@@ -68,6 +68,11 @@ on:
         required: false
         type: string
         default: 'local-latest'
+      requiredModulesListUrl:
+        description: 'The URL of the JSON file with the required modules list'
+        required: false
+        type: string
+        default: ''
       runTests:
         description: 'Run tests'
         required: false

--- a/.github/workflows/e2e-autotests.yml
+++ b/.github/workflows/e2e-autotests.yml
@@ -118,18 +118,19 @@ jobs:
       uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
     - name: Docker Env Full
-      uses: VirtoCommerce/vc-github-actions/docker-env-full@master
+      uses: VirtoCommerce/vc-github-actions/docker-env-full@VCST-4391 #master
       with:
+        customPackagesJsonUrl: ${{ inputs.customPackagesJsonUrl }}
+        customModuleId: ${{ inputs.customModuleId }}
+        customModuleUrl: ${{ inputs.customModuleUrl }}
         frontendZipUrl: ${{ inputs.frontendZipUrl }}
         installModules: ${{ inputs.installModules }}
         installCustomModule: ${{ inputs.installCustomModule }}
         platformDockerTag: ${{ inputs.platformDockerTag }} #'dev-linux-latest'
-        testSecretEnvFile: ${{ secrets.testSecretEnvFile }}
-        customPackagesJsonUrl: ${{ inputs.customPackagesJsonUrl }}
-        customModuleId: ${{ inputs.customModuleId }}
-        customModuleUrl: ${{ inputs.customModuleUrl }}
+        requiredModulesListUrl: ${{ inputs.requiredModulesListUrl }}
         sendgridApiKey: ${{ secrets.sendgridApiKey }}
-    
+        testSecretEnvFile: ${{ secrets.testSecretEnvFile }}
+        
     - name: Run E2E Tests
       uses: VirtoCommerce/vc-github-actions/run-e2e-tests@master
       with:

--- a/.github/workflows/e2e-autotests.yml
+++ b/.github/workflows/e2e-autotests.yml
@@ -123,7 +123,7 @@ jobs:
       uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
     - name: Docker Env Full
-      uses: VirtoCommerce/vc-github-actions/docker-env-full@VCST-4391 #master
+      uses: VirtoCommerce/vc-github-actions/docker-env-full@master
       with:
         customPackagesJsonUrl: ${{ inputs.customPackagesJsonUrl }}
         customModuleId: ${{ inputs.customModuleId }}

--- a/.github/workflows/ui-autotests.yml
+++ b/.github/workflows/ui-autotests.yml
@@ -118,7 +118,7 @@ jobs:
       uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
     - name: Docker Env Full
-      uses: VirtoCommerce/vc-github-actions/docker-env-full@VCST-4391 #master
+      uses: VirtoCommerce/vc-github-actions/docker-env-full@master
       with:
         customModuleId: ${{ inputs.customModuleId }}
         customModuleUrl: ${{ inputs.customModuleUrl }}

--- a/.github/workflows/ui-autotests.yml
+++ b/.github/workflows/ui-autotests.yml
@@ -63,6 +63,11 @@ on:
         required: false
         type: string
         default: 'local-latest'
+      requiredModulesListUrl:
+        description: 'The URL of the JSON file with the required modules list'
+        required: false
+        type: string
+        default: ''
       runTests:
         description: 'Run tests'
         required: false
@@ -113,7 +118,7 @@ jobs:
       uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
     - name: Docker Env Full
-      uses: VirtoCommerce/vc-github-actions/docker-env-full@master
+      uses: VirtoCommerce/vc-github-actions/docker-env-full@VCST-4391 #master
       with:
         customModuleId: ${{ inputs.customModuleId }}
         customModuleUrl: ${{ inputs.customModuleUrl }}
@@ -121,6 +126,7 @@ jobs:
         installCustomModule: ${{ inputs.installCustomModule }}
         installModules: ${{ inputs.installModules }}
         platformDockerTag: ${{ inputs.platformDockerTag }}
+        requiredModulesListUrl: ${{ inputs.requiredModulesListUrl }}
         testSecretEnvFile: ${{ secrets.testSecretEnvFile }}
         sendgridApiKey: ${{ secrets.sendgridApiKey }}
     


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates GitHub Actions workflow inputs and wiring, with no production code changes. Main risk is misconfiguration breaking CI runs if callers pass an invalid `requiredModulesListUrl`.
> 
> **Overview**
> Adds a new optional `requiredModulesListUrl` input to `.github/workflows/ui-autotests.yml` and forwards it into the `docker-env-full` action so UI test runs can bootstrap a specific required-modules set.
> 
> Also fixes a minor formatting issue in `.github/workflows/e2e-autotests.yml` (no functional behavior change).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2584ae36534863d5e52e8f31c52920e5d652088. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->