### PR TITLE
VCST-4391: Bump workflows version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
-# v3.800.24
-# https://virtocommerce.atlassian.net/browse/VCST-4487
+# v3.800.25
+# https://virtocommerce.atlassian.net/browse/VCST-4391
 name: VC build
 
 on:

--- a/.github/workflows/collect-deprecation-warnings.yml
+++ b/.github/workflows/collect-deprecation-warnings.yml
@@ -1,5 +1,5 @@
-# v3.800.24
-# https://virtocommerce.atlassian.net/browse/VCST-4487
+# v3.800.25
+# https://virtocommerce.atlassian.net/browse/VCST-4391
 
 # =======================================================================================
 # The workflow collects deprecation and obsolete warnings from repos in the VirtoCommerce organization.

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -1,5 +1,5 @@
-# v3.800.24
-# https://virtocommerce.atlassian.net/browse/VCST-4487
+# v3.800.25
+# https://virtocommerce.atlassian.net/browse/VCST-4391
 name: VC cloud deployment
 
 on:

--- a/.github/workflows/deploy-module-workflows.yml
+++ b/.github/workflows/deploy-module-workflows.yml
@@ -7,7 +7,7 @@ on:
         description: 'Version to deploy'
         required: true
         type: string
-        default: 'v3.800.24'
+        default: 'v3.800.25'
 
 jobs:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.24
-# https://virtocommerce.atlassian.net/browse/VCST-4487
+# v3.800.25
+# https://virtocommerce.atlassian.net/browse/VCST-4391
 name: VC deployment
 
 on:

--- a/.github/workflows/docker-image-vulnerability-process.yml
+++ b/.github/workflows/docker-image-vulnerability-process.yml
@@ -1,5 +1,5 @@
-# v3.800.24
-# https://virtocommerce.atlassian.net/browse/VCST-4487
+# v3.800.25
+# https://virtocommerce.atlassian.net/browse/VCST-4391
 name: Docker image vulnerability process
 
 on:

--- a/.github/workflows/e2e-autotests.yml
+++ b/.github/workflows/e2e-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.24
-# https://virtocommerce.atlassian.net/browse/VCST-4487
+# v3.800.25
+# https://virtocommerce.atlassian.net/browse/VCST-4391
 name: Common E2E tests
 
 on:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,5 @@
-# v3.800.24
-# https://virtocommerce.atlassian.net/browse/VCST-4487
+# v3.800.25
+# https://virtocommerce.atlassian.net/browse/VCST-4391
 name: Common katalon tests
 
 on:

--- a/.github/workflows/get-metadata.yml
+++ b/.github/workflows/get-metadata.yml
@@ -1,5 +1,5 @@
-# v3.800.24
-# https://virtocommerce.atlassian.net/browse/VCST-4487
+# v3.800.25
+# https://virtocommerce.atlassian.net/browse/VCST-4391
 name: Get metadata
 
 on:

--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -1,5 +1,5 @@
-# v3.800.24
-# https://virtocommerce.atlassian.net/browse/VCST-4487
+# v3.800.25
+# https://virtocommerce.atlassian.net/browse/VCST-4391
 name: Increment version
 
 on:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,5 +1,5 @@
-# v3.800.24
-# https://virtocommerce.atlassian.net/browse/VCST-4487
+# v3.800.25
+# https://virtocommerce.atlassian.net/browse/VCST-4391
 name: VC Publish docker
 
 on:

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -1,5 +1,5 @@
-# v3.800.24
-# https://virtocommerce.atlassian.net/browse/VCST-4487
+# v3.800.25
+# https://virtocommerce.atlassian.net/browse/VCST-4391
 name: VC Publish Github release and Nuget package
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-# v3.800.24
-# https://virtocommerce.atlassian.net/browse/VCST-4487
+# v3.800.25
+# https://virtocommerce.atlassian.net/browse/VCST-4391
 name: Release workflow
 
 on:

--- a/.github/workflows/test-and-sonar.yml
+++ b/.github/workflows/test-and-sonar.yml
@@ -1,5 +1,5 @@
-# v3.800.24
-# https://virtocommerce.atlassian.net/browse/VCST-4487
+# v3.800.25
+# https://virtocommerce.atlassian.net/browse/VCST-4391
 name: VC unit test and sonar scan
 
 on:

--- a/.github/workflows/ui-autotests.yml
+++ b/.github/workflows/ui-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.24
-# https://virtocommerce.atlassian.net/browse/VCST-4487
+# v3.800.25
+# https://virtocommerce.atlassian.net/browse/VCST-4391
 name: Common UI tests
 
 on:

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -1,5 +1,5 @@
-# v3.800.24
-# https://virtocommerce.atlassian.net/browse/VCST-4487
+# v3.800.25
+# https://virtocommerce.atlassian.net/browse/VCST-4391
 name: Module CI
 
 on:
@@ -324,12 +324,13 @@ jobs:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
     needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.24
+    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.25
     with:
       installModules: 'false'
       installCustomModule: 'true'
       customModuleId:  ${{ needs.ci.outputs.moduleId }}
       customModuleUrl:  ${{ needs.ci.outputs.artifactUrl }}
+      requiredModulesListUrl: ${{ needs.ci.outputs.requiredModulesListUrl }}
       runTests: ${{ needs.ci.outputs.run-ui-tests }}
       vctestingRepoBranch: 'dev'
       frontendZipUrl: 'latest'
@@ -342,7 +343,7 @@ jobs:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
     needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/e2e.yml@v3.800.24
+    uses: VirtoCommerce/.github/.github/workflows/e2e.yml@v3.800.25
     with:
       katalonRepo: 'VirtoCommerce/vc-quality-gate-katalon'
       katalonRepoBranch: 'dev'
@@ -363,7 +364,7 @@ jobs:
       && github.event_name == 'push'
       && needs.ci.outputs.deployment-folder-exists == 'true'}}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.24
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.25
     with:
       releaseSource: module
       moduleId: ${{ needs.ci.outputs.moduleId }}

--- a/workflow-templates/module-deploy.yml
+++ b/workflow-templates/module-deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.24
-# https://virtocommerce.atlassian.net/browse/VCST-4487
+# v3.800.25
+# https://virtocommerce.atlassian.net/browse/VCST-4391
 name: Module deployment
 on:
   workflow_dispatch:

--- a/workflow-templates/module-release-hotfix.yml
+++ b/workflow-templates/module-release-hotfix.yml
@@ -1,5 +1,5 @@
-# v3.800.24
-# https://virtocommerce.atlassian.net/browse/VCST-4487
+# v3.800.25
+# https://virtocommerce.atlassian.net/browse/VCST-4391
 name: Release hotfix
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.24
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.25
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.24    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.25    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -46,7 +46,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.24
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.25
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/workflow-templates/publish-nugets.yml
+++ b/workflow-templates/publish-nugets.yml
@@ -1,5 +1,5 @@
-# v3.800.24
-# https://virtocommerce.atlassian.net/browse/VCST-4487
+# v3.800.25
+# https://virtocommerce.atlassian.net/browse/VCST-4391
 name: Publish nuget
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.24    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.25    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.24    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.25    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -29,7 +29,7 @@ jobs:
   publish-nuget:
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.24
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.25
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -1,5 +1,5 @@
-# v3.800.24
-# https://virtocommerce.atlassian.net/browse/VCST-4487
+# v3.800.25
+# https://virtocommerce.atlassian.net/browse/VCST-4391
 name: Release
 
 on:
@@ -7,6 +7,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.24    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.25    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk version bump of GitHub Actions workflow references; main impact is CI/CD behavior changes driven by the updated shared workflow release.
> 
> **Overview**
> Updates this repo’s reusable GitHub Actions workflows and module workflow templates from `v3.800.24` to `v3.800.25` (VCST-4391).
> 
> Also updates the module workflow deployment dispatcher default version to `v3.800.25` and wires `requiredModulesListUrl` through to the `ui-autotests` reusable workflow call.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit daff1375f27f4332326ce726dd57967880dd4917. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->