### PR TITLE
VCST-4845: Remove XAPI dependency for UI-tests run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.28
+# https://virtocommerce.atlassian.net/browse/VCST-4845
 name: VC build
 
 on:

--- a/.github/workflows/collect-deprecation-warnings.yml
+++ b/.github/workflows/collect-deprecation-warnings.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.28
+# https://virtocommerce.atlassian.net/browse/VCST-4845
 
 # =======================================================================================
 # The workflow collects deprecation and obsolete warnings from repos in the VirtoCommerce organization.

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.28
+# https://virtocommerce.atlassian.net/browse/VCST-4845
 name: VC cloud deployment
 
 on:

--- a/.github/workflows/deploy-module-workflows.yml
+++ b/.github/workflows/deploy-module-workflows.yml
@@ -7,7 +7,7 @@ on:
         description: 'Version to deploy'
         required: true
         type: string
-        default: 'v3.800.27'
+        default: 'v3.800.28'
 
 jobs:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.28
+# https://virtocommerce.atlassian.net/browse/VCST-4845
 name: VC deployment
 
 on:

--- a/.github/workflows/docker-image-vulnerability-process.yml
+++ b/.github/workflows/docker-image-vulnerability-process.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.28
+# https://virtocommerce.atlassian.net/browse/VCST-4845
 name: Docker image vulnerability process
 
 on:

--- a/.github/workflows/e2e-autotests.yml
+++ b/.github/workflows/e2e-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.28
+# https://virtocommerce.atlassian.net/browse/VCST-4845
 name: Common E2E tests
 
 on:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.28
+# https://virtocommerce.atlassian.net/browse/VCST-4845
 name: Common katalon tests
 
 on:

--- a/.github/workflows/get-metadata.yml
+++ b/.github/workflows/get-metadata.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.28
+# https://virtocommerce.atlassian.net/browse/VCST-4845
 name: Get metadata
 
 on:

--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.28
+# https://virtocommerce.atlassian.net/browse/VCST-4845
 name: Increment version
 
 on:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.28
+# https://virtocommerce.atlassian.net/browse/VCST-4845
 name: VC Publish docker
 
 on:

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.28
+# https://virtocommerce.atlassian.net/browse/VCST-4845
 name: VC Publish Github release and Nuget package
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.28
+# https://virtocommerce.atlassian.net/browse/VCST-4845
 name: Release workflow
 
 on:

--- a/.github/workflows/test-and-sonar.yml
+++ b/.github/workflows/test-and-sonar.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.28
+# https://virtocommerce.atlassian.net/browse/VCST-4845
 name: VC unit test and sonar scan
 
 on:

--- a/.github/workflows/ui-autotests.yml
+++ b/.github/workflows/ui-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.28
+# https://virtocommerce.atlassian.net/browse/VCST-4845
 name: Common UI tests
 
 on:

--- a/.github/workflows/ui-autotests.yml
+++ b/.github/workflows/ui-autotests.yml
@@ -68,11 +68,6 @@ on:
         required: false
         type: string
         default: ''
-      runTests:
-        description: 'Run tests'
-        required: false
-        type: string
-        default: 'true'
       vctestingPath:
         description: 'UI tests path'
         required: false
@@ -98,16 +93,7 @@ on:
         required: true
 
 jobs:
-  dry-run:
-    if: ${{ inputs.runTests == 'false' }}
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Check if runTests is enabled
-        run: |
-          echo "RunTests is disabled"
-
   ui-autotests:
-    if: ${{ inputs.runTests == 'true' }}
     runs-on: ubuntu-22.04
 
     env:

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.28
+# https://virtocommerce.atlassian.net/browse/VCST-4845
 name: Module CI
 
 on:
@@ -302,7 +302,7 @@ jobs:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
     needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.27
+    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.28
     with:
       installModules: 'false'
       installCustomModule: 'true'
@@ -320,7 +320,7 @@ jobs:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
     needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/e2e.yml@v3.800.27
+    uses: VirtoCommerce/.github/.github/workflows/e2e.yml@v3.800.28
     with:
       katalonRepo: 'VirtoCommerce/vc-quality-gate-katalon'
       katalonRepoBranch: 'dev'
@@ -341,7 +341,7 @@ jobs:
       && github.event_name == 'push'
       && needs.ci.outputs.deployment-folder-exists == 'true'}}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.27
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.28
     with:
       releaseSource: module
       moduleId: ${{ needs.ci.outputs.moduleId }}

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -309,7 +309,6 @@ jobs:
       customModuleId:  ${{ needs.ci.outputs.moduleId }}
       customModuleUrl:  ${{ needs.ci.outputs.artifactUrl }}
       requiredModulesListUrl: ${{ needs.ci.outputs.requiredModulesListUrl }}
-      runTests: 'true'
       vctestingRepoBranch: 'dev'
       frontendZipUrl: 'latest'
     secrets:

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -54,7 +54,6 @@ jobs:
       moduleId: ${{ steps.artifact_ver.outputs.moduleId }}
       matrix: ${{ steps.deployment-matrix.outputs.matrix }}
       run-e2e: ${{ steps.run-e2e.outputs.result }}
-      run-ui-tests: ${{ steps.run-ui-tests.outputs.result }}
       deployment-folder-exists: ${{ steps.check_deployment_folder.outputs.exists }}
       requiredModulesListUrl: ${{ steps.extract_required_modules_list_url_from_pr.outputs.url }}
 
@@ -253,27 +252,6 @@ jobs:
             Add-Content -Path $env:GITHUB_OUTPUT -Value "url="
           }
 
-      - name: Look for xapi module in dependencies
-        id: run-ui-tests
-        shell: pwsh
-        run: |
-          $manifestFile = Get-ChildItem -Path ${{ github.workspace }} -Recurse -Filter "module.manifest" | Where-Object { $_.FullName -like "*/src/*/module.manifest" } | Select-Object -First 1
-          if (-not $manifestFile) {
-            Write-Error "No module.manifest file found in src subdirectories"
-            exit 1
-          }
-          Write-Host "Found module.manifest at: $($manifestFile.FullName)"
-          $manifestContent = Get-Content $manifestFile.FullName -Raw
-          $containsXapi = 'false'
-          $dependecies = $(Select-Xml -Content $manifestContent -XPath "//dependencies").Node.dependency
-          foreach ($dependency in $dependecies) {
-            if ($dependency.id -eq 'VirtoCommerce.Xapi') {
-              Write-Host "Found VirtoCommerce.Xapi in dependencies"
-              $containsXapi = 'true'
-            }
-          }
-          echo "result=$containsXapi" >> $env:GITHUB_OUTPUT
-
       - name: Setup Git Credentials
         if: ${{ (github.ref == 'refs/heads/dev' && github.event_name != 'workflow_dispatch') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
         uses: VirtoCommerce/vc-github-actions/setup-git-credentials-github@master
@@ -331,7 +309,7 @@ jobs:
       customModuleId:  ${{ needs.ci.outputs.moduleId }}
       customModuleUrl:  ${{ needs.ci.outputs.artifactUrl }}
       requiredModulesListUrl: ${{ needs.ci.outputs.requiredModulesListUrl }}
-      runTests: ${{ needs.ci.outputs.run-ui-tests }}
+      runTests: 'true'
       vctestingRepoBranch: 'dev'
       frontendZipUrl: 'latest'
     secrets:

--- a/workflow-templates/module-deploy.yml
+++ b/workflow-templates/module-deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.28
+# https://virtocommerce.atlassian.net/browse/VCST-4845
 name: Module deployment
 on:
   workflow_dispatch:

--- a/workflow-templates/module-release-hotfix.yml
+++ b/workflow-templates/module-release-hotfix.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.28
+# https://virtocommerce.atlassian.net/browse/VCST-4845
 name: Release hotfix
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.27
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.28
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.27    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.28    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -46,7 +46,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.27
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.28
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/workflow-templates/publish-nugets.yml
+++ b/workflow-templates/publish-nugets.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.28
+# https://virtocommerce.atlassian.net/browse/VCST-4845
 name: Publish nuget
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.27    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.28    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.27    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.28    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -29,7 +29,7 @@ jobs:
   publish-nuget:
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.27
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.28
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.28
+# https://virtocommerce.atlassian.net/browse/VCST-4845
 name: Release
 
 on:
@@ -7,6 +7,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.27    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.28    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes CI workflow behavior by always running UI autotests and removing the prior XAPI-dependency gate, which could impact pipeline runtime/coverage. No application/runtime code paths are affected.
> 
> **Overview**
> Updates reusable GitHub workflow templates/references to `v3.800.28` across the org.
> 
> **UI autotest gating is removed**: `ui-autotests.yml` drops the `runTests` input and the associated conditional `dry-run` job/`if` guards, and `module-ci.yml` removes the step that inspected `module.manifest` for `VirtoCommerce.Xapi` and no longer forwards `runTests` based on that check—so UI tests run whenever the `ui-auto-tests` job is invoked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52dc60973f1db0d16d0d34761934ba22d32bd2b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->