### PR TITLE
VCST-4958: Add a workflow for refactored autotests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: VC build
 
 on:

--- a/.github/workflows/collect-deprecation-warnings.yml
+++ b/.github/workflows/collect-deprecation-warnings.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 
 # =======================================================================================
 # The workflow collects deprecation and obsolete warnings from repos in the VirtoCommerce organization.

--- a/.github/workflows/create-module-repository.yml
+++ b/.github/workflows/create-module-repository.yml
@@ -395,7 +395,7 @@ jobs:
                 "license/cla",
                 "ci",
                 "SonarCloud Code Analysis",
-                "module-katalon-tests / e2e-tests"
+                "auto-tests / auto-autotests"
               ]
             },
             "enforce_admins": false,

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: VC cloud deployment
 
 on:

--- a/.github/workflows/deploy-module-workflows.yml
+++ b/.github/workflows/deploy-module-workflows.yml
@@ -7,7 +7,7 @@ on:
         description: 'Version to deploy'
         required: true
         type: string
-        default: 'v3.800.29'
+        default: 'v3.800.30'
 
 jobs:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: VC deployment
 
 on:

--- a/.github/workflows/docker-image-vulnerability-process.yml
+++ b/.github/workflows/docker-image-vulnerability-process.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Docker image vulnerability process
 
 on:

--- a/.github/workflows/e2e-autotests.yml
+++ b/.github/workflows/e2e-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Common E2E tests
 
 on:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Common katalon tests
 
 on:

--- a/.github/workflows/get-metadata.yml
+++ b/.github/workflows/get-metadata.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Get metadata
 
 on:

--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Increment version
 
 on:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: VC Publish docker
 
 on:

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: VC Publish Github release and Nuget package
 
 on:

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Auto tests
 
 on:

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -1,6 +1,6 @@
 # v3.800.29
 # https://virtocommerce.atlassian.net/browse/VCST-4770
-name: Common tests
+name: Auto tests
 
 on:
   workflow_call:
@@ -121,7 +121,7 @@ jobs:
         customModuleUrl: ${{ inputs.customModuleUrl }}
         sendgridApiKey: ${{ secrets.sendgridApiKey }}
     
-    - name: Run Pytest Tests
+    - name: Run Auto Tests
       uses: VirtoCommerce/vc-github-actions/run-pytest-tests@VCST-4958
       with:
         testSecretEnvFile: ${{ secrets.testSecretEnvFile }}

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -120,7 +120,7 @@ jobs:
       uses: VirtoCommerce/vc-github-actions/run-pytest-tests@VCST-4958
       with:
         testSecretEnvFile: ${{ secrets.testSecretEnvFile }}
-        testSuites: 'graphql,restapi,e2e'
+        testSuites: 'graphql'
         vctestingPath: ${{ inputs.vctestingPath }}
         vctestingRepo: ${{ inputs.vctestingRepo }}
         vctestingRepoBranch: ${{ inputs.vctestingRepoBranch }}

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -68,6 +68,11 @@ on:
         required: false
         type: string
         default: 'local-latest'
+      testSuites:
+        description: 'Comma-separated list of suites to run. Any subset of: graphql, restapi, e2e'
+        required: false
+        default: 'graphql,restapi,e2e'
+        type: string
       vctestingPath:
         description: 'UI tests path'
         required: false
@@ -120,7 +125,7 @@ jobs:
       uses: VirtoCommerce/vc-github-actions/run-pytest-tests@VCST-4958
       with:
         testSecretEnvFile: ${{ secrets.testSecretEnvFile }}
-        testSuites: 'graphql'
+        testSuites: ${{ inputs.testSuites }}
         vctestingPath: ${{ inputs.vctestingPath }}
         vctestingRepo: ${{ inputs.vctestingRepo }}
         vctestingRepoBranch: ${{ inputs.vctestingRepoBranch }}

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -98,7 +98,7 @@ on:
         required: true
 
 jobs:
-  e2e-autotests:
+  auto-autotests:
     runs-on: ubuntu-22.04
 
     env:

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -111,10 +111,10 @@ jobs:
 
     steps:
     - name: Install VirtoCommerce.GlobalTool
-      uses: VirtoCommerce/vc-github-actions/setup-vcbuild@VCST-4958
+      uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
     - name: Docker Env Full
-      uses: VirtoCommerce/vc-github-actions/docker-env-full@VCST-4958
+      uses: VirtoCommerce/vc-github-actions/docker-env-full@master
       with:
         frontendZipUrl: ${{ inputs.frontendZipUrl }}
         installModules: ${{ inputs.installModules }}
@@ -128,7 +128,7 @@ jobs:
         sendgridApiKey: ${{ secrets.sendgridApiKey }}
     
     - name: Run Auto Tests
-      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@VCST-4958
+      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@master
       with:
         testSecretEnvFile: ${{ secrets.testSecretEnvFile }}
         testSuites: ${{ inputs.testSuites }}

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -130,6 +130,12 @@ jobs:
     - name: Run Auto Tests
       uses: VirtoCommerce/vc-github-actions/run-pytest-tests@master
       with:
+        adminPassword: ${{ inputs.adminPassword }}
+        adminUsername: ${{ inputs.adminUsername }}
+        apiKey: ${{ inputs.apiKey }}
+        backUrl: ${{ inputs.backUrl }}
+        baseUrl: ${{ inputs.baseUrl }}
+        browser: ${{ inputs.browser }}
         testSecretEnvFile: ${{ secrets.testSecretEnvFile }}
         testSuites: ${{ inputs.testSuites }}
         vctestingPath: ${{ inputs.vctestingPath }}

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -68,6 +68,11 @@ on:
         required: false
         type: string
         default: 'local-latest'
+      requiredModulesListUrl:
+        description: 'The URL of the JSON file with the required modules list'
+        required: false
+        type: string
+        default: ''
       testSuites:
         description: 'Comma-separated list of suites to run. Any subset of: graphql, restapi, e2e'
         required: false
@@ -115,6 +120,7 @@ jobs:
         installModules: ${{ inputs.installModules }}
         installCustomModule: ${{ inputs.installCustomModule }}
         platformDockerTag: ${{ inputs.platformDockerTag }}
+        requiredModulesListUrl: ${{ inputs.requiredModulesListUrl }}
         testSecretEnvFile: ${{ secrets.testSecretEnvFile }}
         customPackagesJsonUrl: ${{ inputs.customPackagesJsonUrl }}
         customModuleId: ${{ inputs.customModuleId }}

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -1,0 +1,126 @@
+# v3.800.29
+# https://virtocommerce.atlassian.net/browse/VCST-4770
+name: Common tests
+
+on:
+  workflow_call:
+    inputs:
+      adminPassword:
+        description: 'Admin Password'
+        required: false
+        type: string
+        default: 'Password3'
+      adminUsername:
+        description: 'Admin Username'
+        required: false
+        type: string
+        default: 'admin'
+      apiKey:
+        description: 'API Key'
+        required: false
+        type: string
+        default: '1add83ea-2235-41fe-b623-825070824059'
+      backUrl:
+        description: 'Back URL'
+        required: false
+        type: string
+        default: 'http://localhost:8090'
+      baseUrl:
+        description: 'Base URL'
+        required: false
+        type: string
+        default: 'http://localhost'
+      browser:
+        required: false
+        type: string
+        default: 'chromium'
+      customModuleId:
+        description: 'Custom Module id'
+        required: false
+        type: string
+        default: ''
+      customModuleUrl:
+        description: 'Custom module Module url'
+        required: false
+        type: string
+        default: ''
+      customPackagesJsonUrl:
+        description: 'Custom packages.json url'
+        required: false
+        type: string
+        default: ''
+      frontendZipUrl:
+        required: false
+        type: string
+        default: 'latest'
+      installCustomModule:
+        description: 'Enable or disable "Install Custom Modules" step'
+        required: false
+        type: string
+        default: 'false'
+      installModules:
+        description: 'Enable or disable "Install Modules" step'
+        required: false
+        type: string
+        default: 'true'
+      platformDockerTag:
+        description: 'Platform docker tag'
+        required: false
+        type: string
+        default: 'local-latest'
+      vctestingPath:
+        description: 'UI tests path'
+        required: false
+        type: string
+        default: 'vc-testing-module'
+      vctestingRepo:
+        description: 'UI tests repository'
+        required: false
+        type: string
+        default: 'VirtoCommerce/vc-testing-module'
+      vctestingRepoBranch:
+        description: 'UI tests repository branch'
+        required: false
+        type: string
+        default: 'dev'
+
+    secrets:
+      envPAT:
+        required: true
+      sendgridApiKey:
+        required: true
+      testSecretEnvFile:
+        required: true
+
+jobs:
+  e2e-autotests:
+    runs-on: ubuntu-22.04
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.envPAT }}
+
+    steps:
+    - name: Install VirtoCommerce.GlobalTool
+      uses: VirtoCommerce/vc-github-actions/setup-vcbuild@VCST-4958
+
+    - name: Docker Env Full
+      uses: VirtoCommerce/vc-github-actions/docker-env-full@VCST-4958
+      with:
+        frontendZipUrl: ${{ inputs.frontendZipUrl }}
+        installModules: ${{ inputs.installModules }}
+        installCustomModule: ${{ inputs.installCustomModule }}
+        platformDockerTag: ${{ inputs.platformDockerTag }}
+        testSecretEnvFile: ${{ secrets.testSecretEnvFile }}
+        customPackagesJsonUrl: ${{ inputs.customPackagesJsonUrl }}
+        customModuleId: ${{ inputs.customModuleId }}
+        customModuleUrl: ${{ inputs.customModuleUrl }}
+        sendgridApiKey: ${{ secrets.sendgridApiKey }}
+    
+    - name: Run Pytest Tests
+      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@VCST-4958
+      with:
+        testSecretEnvFile: ${{ secrets.testSecretEnvFile }}
+        testSuites: 'graphql,restapi,e2e'
+        vctestingPath: ${{ inputs.vctestingPath }}
+        vctestingRepo: ${{ inputs.vctestingRepo }}
+        vctestingRepoBranch: ${{ inputs.vctestingRepoBranch }}

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -19,7 +19,7 @@ on:
         description: 'API Key'
         required: false
         type: string
-        default: '1add83ea-2235-41fe-b623-825070824059'
+        default: ''
       backUrl:
         description: 'Back URL'
         required: false

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -128,7 +128,7 @@ jobs:
         sendgridApiKey: ${{ secrets.sendgridApiKey }}
     
     - name: Run Auto Tests
-      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@VCST-4958 #master
+      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@master
       with:
         adminPassword: ${{ inputs.adminPassword }}
         adminUsername: ${{ inputs.adminUsername }}

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -9,7 +9,7 @@ on:
         description: 'Admin Password'
         required: false
         type: string
-        default: 'Password3'
+        default: ''
       adminUsername:
         description: 'Admin Username'
         required: false

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -128,7 +128,7 @@ jobs:
         sendgridApiKey: ${{ secrets.sendgridApiKey }}
     
     - name: Run Auto Tests
-      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@master
+      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@VCST-4958 #master
       with:
         adminPassword: ${{ inputs.adminPassword }}
         adminUsername: ${{ inputs.adminUsername }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Release workflow
 
 on:

--- a/.github/workflows/test-and-sonar.yml
+++ b/.github/workflows/test-and-sonar.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: VC unit test and sonar scan
 
 on:

--- a/.github/workflows/ui-autotests.yml
+++ b/.github/workflows/ui-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Common UI tests
 
 on:

--- a/scripts/Update-ModuleBranchProtection.ps1
+++ b/scripts/Update-ModuleBranchProtection.ps1
@@ -19,15 +19,21 @@
 #>
 [CmdletBinding(SupportsShouldProcess = $true)]
 param(
-    [string]$Org = 'VirtoCommerce',
+    [string]$Org = 'AndrewEhloOrg', #'VirtoCommerce',
     [string[]]$Repos,
     [string[]]$Branches = @('main', 'dev'),
     [string]$OldCheck = 'module-katalon-tests / e2e-tests',
     [string]$NewCheck = 'auto-tests / auto-autotests',
-    [switch]$AddIfMissing
+    [switch]$AddIfMissing,
+    # PAT with repo admin on the target repos. If omitted, falls back to existing
+    # $env:GH_TOKEN or the ambient `gh auth login` session.
+    [string]$Token
 )
 
 $ErrorActionPreference = 'Stop'
+
+$priorGhToken = $env:GH_TOKEN
+if ($Token) { $env:GH_TOKEN = $Token }
 
 function Test-GhReady {
     $null = gh auth status 2>&1
@@ -151,44 +157,54 @@ function Update-BranchProtection {
     return [pscustomobject]@{ Status = 'OK'; Reason = $action }
 }
 
-Test-GhReady
+try {
+    Test-GhReady
 
-if (-not $Repos -or $Repos.Count -eq 0) {
-    Write-Host "Discovering vc-module-* repos in $Org ..."
-    $Repos = Get-ModuleRepos -Org $Org
-    Write-Host "Found $($Repos.Count) module repos."
-}
-else {
-    $Repos = $Repos | ForEach-Object { if ($_ -match '/') { $_ } else { "$Org/$_" } }
-}
+    if (-not $Repos -or $Repos.Count -eq 0) {
+        Write-Host "Discovering vc-module-* repos in $Org ..."
+        $Repos = Get-ModuleRepos -Org $Org
+        Write-Host "Found $($Repos.Count) module repos."
+    }
+    else {
+        $Repos = $Repos | ForEach-Object { if ($_ -match '/') { $_ } else { "$Org/$_" } }
+    }
 
-$results = foreach ($repo in $Repos) {
-    foreach ($branch in $Branches) {
-        $r = Update-BranchProtection `
-            -RepoFull $repo -Branch $branch `
-            -OldCheck $OldCheck -NewCheck $NewCheck `
-            -AddIfMissing:$AddIfMissing
-        $line = [pscustomobject]@{
-            Repo   = $repo
-            Branch = $branch
-            Status = $r.Status
-            Reason = $r.Reason
+    $results = foreach ($repo in $Repos) {
+        foreach ($branch in $Branches) {
+            $r = Update-BranchProtection `
+                -RepoFull $repo -Branch $branch `
+                -OldCheck $OldCheck -NewCheck $NewCheck `
+                -AddIfMissing:$AddIfMissing
+            $line = [pscustomobject]@{
+                Repo   = $repo
+                Branch = $branch
+                Status = $r.Status
+                Reason = $r.Reason
+            }
+            $color = switch ($r.Status) {
+                'OK'     { 'Green' }
+                'WHATIF' { 'Cyan' }
+                'SKIP'   { 'DarkGray' }
+                'ERROR'  { 'Red' }
+                default  { 'White' }
+            }
+            Write-Host ("[{0,-6}] {1}/{2}: {3}" -f $r.Status, $repo, $branch, $r.Reason) -ForegroundColor $color
+            $line
         }
-        $color = switch ($r.Status) {
-            'OK'     { 'Green' }
-            'WHATIF' { 'Cyan' }
-            'SKIP'   { 'DarkGray' }
-            'ERROR'  { 'Red' }
-            default  { 'White' }
-        }
-        Write-Host ("[{0,-6}] {1}/{2}: {3}" -f $r.Status, $repo, $branch, $r.Reason) -ForegroundColor $color
-        $line
+    }
+
+    Write-Host ''
+    Write-Host 'Summary:' -ForegroundColor Yellow
+    $results | Group-Object Status | Select-Object Name, Count | Format-Table -AutoSize
+
+    $errors = @($results | Where-Object Status -eq 'ERROR')
+    if ($errors.Count -gt 0) { exit 1 }
+}
+finally {
+    # Restore (or clear) GH_TOKEN so a -Token passed to this script doesn't leak
+    # into the caller's session when dot-sourced.
+    if ($Token) {
+        if ($null -ne $priorGhToken) { $env:GH_TOKEN = $priorGhToken }
+        else { Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue }
     }
 }
-
-Write-Host ''
-Write-Host 'Summary:' -ForegroundColor Yellow
-$results | Group-Object Status | Select-Object Name, Count | Format-Table -AutoSize
-
-$errors = @($results | Where-Object Status -eq 'ERROR')
-if ($errors.Count -gt 0) { exit 1 }

--- a/scripts/Update-ModuleBranchProtection.ps1
+++ b/scripts/Update-ModuleBranchProtection.ps1
@@ -19,7 +19,7 @@
 #>
 [CmdletBinding(SupportsShouldProcess = $true)]
 param(
-    [string]$Org = 'AndrewEhloOrg', #'VirtoCommerce',
+    [string]$Org = 'VirtoCommerce',
     [string[]]$Repos,
     [string[]]$Branches = @('main', 'dev'),
     [string]$OldCheck = 'module-katalon-tests / e2e-tests',

--- a/scripts/Update-ModuleBranchProtection.ps1
+++ b/scripts/Update-ModuleBranchProtection.ps1
@@ -1,0 +1,194 @@
+#requires -Version 7.0
+<#
+.SYNOPSIS
+    Swap a required status check on protected branches of existing module repos.
+
+.DESCRIPTION
+    Mirrors the change applied to new repos by
+    .github/workflows/create-module-repository.yml (the "Protect branches" step):
+    replaces the old required status check with the new one on `main` and `dev`.
+
+    Read-modify-write: fetches each branch's current protection, updates only the
+    contexts list, and PUTs it back. Other settings (reviews, enforce_admins,
+    restrictions, etc.) are preserved as-is.
+
+.EXAMPLE
+    pwsh ./Update-ModuleBranchProtection.ps1 -WhatIf
+    pwsh ./Update-ModuleBranchProtection.ps1
+    pwsh ./Update-ModuleBranchProtection.ps1 -Repos vc-module-news,vc-module-cart
+#>
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [string]$Org = 'VirtoCommerce',
+    [string[]]$Repos,
+    [string[]]$Branches = @('main', 'dev'),
+    [string]$OldCheck = 'module-katalon-tests / e2e-tests',
+    [string]$NewCheck = 'auto-tests / auto-autotests',
+    [switch]$AddIfMissing
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Test-GhReady {
+    $null = gh auth status 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw 'gh CLI is not authenticated. Run: gh auth login (needs `repo` + `admin:repo_hook` scopes).'
+    }
+}
+
+function Get-ModuleRepos {
+    param([string]$Org)
+    $json = gh repo list $Org --limit 1000 --no-archived --json name 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "Failed to list repos for $Org`: $json" }
+    ($json | ConvertFrom-Json) |
+        Where-Object { $_.name -like 'vc-module-*' } |
+        ForEach-Object { "$Org/$($_.name)" } |
+        Sort-Object
+}
+
+function Get-Enabled {
+    param($Obj, [string]$Name)
+    if ($Obj -and $Obj.PSObject.Properties.Name -contains $Name) {
+        return [bool]$Obj.$Name.enabled
+    }
+    return $false
+}
+
+function Update-BranchProtection {
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param(
+        [string]$RepoFull,
+        [string]$Branch,
+        [string]$OldCheck,
+        [string]$NewCheck,
+        [bool]$AddIfMissing
+    )
+
+    $raw = gh api "/repos/$RepoFull/branches/$Branch/protection" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        $reason = if ("$raw" -match 'Not Found|HTTP 404|Branch not protected') { 'no protection / branch missing' } else { "$raw" }
+        return [pscustomobject]@{ Status = 'SKIP'; Reason = $reason }
+    }
+
+    $p   = $raw | ConvertFrom-Json
+    $rsc = $p.required_status_checks
+    if (-not $rsc) {
+        return [pscustomobject]@{ Status = 'SKIP'; Reason = 'no required_status_checks' }
+    }
+
+    $contexts = @($rsc.contexts)
+    $hasOld   = $contexts -contains $OldCheck
+    $hasNew   = $contexts -contains $NewCheck
+
+    if ($hasOld) {
+        $contexts = @($contexts | Where-Object { $_ -ne $OldCheck })
+        if (-not $hasNew) { $contexts += $NewCheck }
+    }
+    elseif ($AddIfMissing -and -not $hasNew) {
+        $contexts += $NewCheck
+    }
+    else {
+        $reason = if ($hasNew) { 'already up to date' } else { 'old check not present (use -AddIfMissing to add anyway)' }
+        return [pscustomobject]@{ Status = 'SKIP'; Reason = $reason }
+    }
+
+    # GET returns nested { enabled: bool } objects; PUT expects flat booleans.
+    $payload = [ordered]@{
+        required_status_checks = [ordered]@{
+            strict   = [bool]$rsc.strict
+            contexts = @($contexts)
+        }
+        enforce_admins                   = Get-Enabled $p 'enforce_admins'
+        required_pull_request_reviews    = $null
+        restrictions                     = $null
+        required_linear_history          = Get-Enabled $p 'required_linear_history'
+        allow_force_pushes               = Get-Enabled $p 'allow_force_pushes'
+        allow_deletions                  = Get-Enabled $p 'allow_deletions'
+        block_creations                  = Get-Enabled $p 'block_creations'
+        required_conversation_resolution = Get-Enabled $p 'required_conversation_resolution'
+        lock_branch                      = Get-Enabled $p 'lock_branch'
+        allow_fork_syncing               = Get-Enabled $p 'allow_fork_syncing'
+    }
+
+    if ($p.required_pull_request_reviews) {
+        $r = $p.required_pull_request_reviews
+        $payload.required_pull_request_reviews = [ordered]@{
+            dismiss_stale_reviews           = [bool]$r.dismiss_stale_reviews
+            require_code_owner_reviews      = [bool]$r.require_code_owner_reviews
+            required_approving_review_count = [int]$r.required_approving_review_count
+            require_last_push_approval      = [bool]$r.require_last_push_approval
+        }
+    }
+
+    if ($p.restrictions) {
+        $payload.restrictions = [ordered]@{
+            users = @($p.restrictions.users | ForEach-Object { $_.login })
+            teams = @($p.restrictions.teams | ForEach-Object { $_.slug })
+            apps  = @($p.restrictions.apps  | ForEach-Object { $_.slug })
+        }
+    }
+
+    $target = "$RepoFull/$Branch"
+    $action = "contexts -> [$($contexts -join ', ')]"
+    if (-not $PSCmdlet.ShouldProcess($target, $action)) {
+        return [pscustomobject]@{ Status = 'WHATIF'; Reason = $action }
+    }
+
+    $json = $payload | ConvertTo-Json -Depth 10 -Compress
+    $tmp  = New-TemporaryFile
+    try {
+        # UTF-8 without BOM; gh on Windows mishandles BOM in --input payloads.
+        [System.IO.File]::WriteAllText($tmp.FullName, $json, [System.Text.UTF8Encoding]::new($false))
+        $out = gh api --method PUT "/repos/$RepoFull/branches/$Branch/protection" --input $tmp.FullName 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            return [pscustomobject]@{ Status = 'ERROR'; Reason = "$out" }
+        }
+    }
+    finally {
+        Remove-Item $tmp.FullName -ErrorAction SilentlyContinue
+    }
+
+    return [pscustomobject]@{ Status = 'OK'; Reason = $action }
+}
+
+Test-GhReady
+
+if (-not $Repos -or $Repos.Count -eq 0) {
+    Write-Host "Discovering vc-module-* repos in $Org ..."
+    $Repos = Get-ModuleRepos -Org $Org
+    Write-Host "Found $($Repos.Count) module repos."
+}
+else {
+    $Repos = $Repos | ForEach-Object { if ($_ -match '/') { $_ } else { "$Org/$_" } }
+}
+
+$results = foreach ($repo in $Repos) {
+    foreach ($branch in $Branches) {
+        $r = Update-BranchProtection `
+            -RepoFull $repo -Branch $branch `
+            -OldCheck $OldCheck -NewCheck $NewCheck `
+            -AddIfMissing:$AddIfMissing
+        $line = [pscustomobject]@{
+            Repo   = $repo
+            Branch = $branch
+            Status = $r.Status
+            Reason = $r.Reason
+        }
+        $color = switch ($r.Status) {
+            'OK'     { 'Green' }
+            'WHATIF' { 'Cyan' }
+            'SKIP'   { 'DarkGray' }
+            'ERROR'  { 'Red' }
+            default  { 'White' }
+        }
+        Write-Host ("[{0,-6}] {1}/{2}: {3}" -f $r.Status, $repo, $branch, $r.Reason) -ForegroundColor $color
+        $line
+    }
+}
+
+Write-Host ''
+Write-Host 'Summary:' -ForegroundColor Yellow
+$results | Group-Object Status | Select-Object Name, Count | Format-Table -AutoSize
+
+$errors = @($results | Where-Object Status -eq 'ERROR')
+if ($errors.Count -gt 0) { exit 1 }

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Module CI
 
 on:
@@ -298,11 +298,11 @@ jobs:
         run: |
           echo "Jira Upload Build Info response: ${{ steps.push_build_info_to_jira.outputs.response }}"
 
-  ui-auto-tests:
+  auto-tests:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
-    needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.29
+    needs: ci
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.30
     with:
       installModules: 'false'
       installCustomModule: 'true'
@@ -311,37 +311,18 @@ jobs:
       requiredModulesListUrl: ${{ needs.ci.outputs.requiredModulesListUrl }}
       vctestingRepoBranch: 'dev'
       frontendZipUrl: 'latest'
+      testSuites: 'graphql,restapi'
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}
       testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
       sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
-
-  module-katalon-tests:
-    if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
-        (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/e2e.yml@v3.800.29
-    with:
-      katalonRepo: 'VirtoCommerce/vc-quality-gate-katalon'
-      katalonRepoBranch: 'dev'
-      testSuite: 'Test Suites/Modules/Platform_collection'
-      installModules: 'false'
-      installCustomModule: 'true'
-      customModuleId:  ${{ needs.ci.outputs.moduleId }}
-      customModuleUrl:  ${{ needs.ci.outputs.artifactUrl }}
-      requiredModulesListUrl: ${{ needs.ci.outputs.requiredModulesListUrl }}
-      platformDockerTag: 'dev-linux-latest'
-      storefrontDockerTag: 'dev-linux-latest'
-    secrets:
-      envPAT: ${{ secrets.REPO_TOKEN }}
-      katalonApiKey: ${{ secrets.KATALON_API_KEY }}
 
   deploy-cloud:
     if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
       && github.event_name == 'push'
       && needs.ci.outputs.deployment-folder-exists == 'true'}}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.29
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.30
     with:
       releaseSource: module
       moduleId: ${{ needs.ci.outputs.moduleId }}

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -53,7 +53,6 @@ jobs:
       version: ${{ steps.artifact_ver.outputs.shortVersion }}
       moduleId: ${{ steps.artifact_ver.outputs.moduleId }}
       matrix: ${{ steps.deployment-matrix.outputs.matrix }}
-      run-e2e: ${{ steps.run-e2e.outputs.result }}
       deployment-folder-exists: ${{ steps.check_deployment_folder.outputs.exists }}
       requiredModulesListUrl: ${{ steps.extract_required_modules_list_url_from_pr.outputs.url }}
 
@@ -209,18 +208,6 @@ jobs:
         with:
           deployConfigPath: '.deployment/module/cloudDeploy.json'
           releaseBranch: 'master'
-
-      - name: Check commit message for version number
-        id: run-e2e
-        env:
-          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-        run: |
-          if [[ "$COMMIT_MESSAGE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]];
-          then
-            echo "result=false" >> $GITHUB_OUTPUT
-          else
-            echo "result=true" >> $GITHUB_OUTPUT
-          fi
 
       - name: Extract required modules list URL from the pull request description
         if: ${{ github.event_name == 'pull_request' }}

--- a/workflow-templates/module-deploy.yml
+++ b/workflow-templates/module-deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Module deployment
 on:
   workflow_dispatch:

--- a/workflow-templates/module-release-hotfix.yml
+++ b/workflow-templates/module-release-hotfix.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Release hotfix
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.29
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.30
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.29    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.30    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -46,7 +46,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.29
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.30
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/workflow-templates/publish-nugets.yml
+++ b/workflow-templates/publish-nugets.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Publish nuget
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.29    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.30    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.29    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.30    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -29,7 +29,7 @@ jobs:
   publish-nuget:
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.29
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.30
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Release
 
 on:
@@ -7,6 +7,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.29    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.30    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
Addnew workflow running graphql, restapi and e2e autotests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI and branch-protection status checks are renamed/replaced; misalignment between required checks and workflow/job names could block PR merges or allow missing test coverage if not updated consistently.
> 
> **Overview**
> Adds a new reusable GitHub Actions workflow, `pytest-tests.yml`, to provision a full Docker test environment and run consolidated pytest suites (`graphql`, `restapi`, `e2e`) via `run-pytest-tests`.
> 
> Updates module scaffolding and templates to **replace the legacy Katalon-required check** (`module-katalon-tests / e2e-tests`) with the new `auto-tests / auto-autotests` check, and changes `workflow-templates/module-ci.yml` to call the new workflow (dropping the old commit-message gate/output and removing the separate `module-katalon-tests` job). Also bumps referenced workflow versions/defaults from `v3.800.29` to `v3.800.30` across templates/workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5384c0b64c2eff11722b44d588d5f2b200480fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->