### PR TITLE
VCST-5041: Add db provider matrix for pytest-tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.31
+# https://virtocommerce.atlassian.net/browse/VCST-5041
 name: VC build
 
 on:

--- a/.github/workflows/collect-deprecation-warnings.yml
+++ b/.github/workflows/collect-deprecation-warnings.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.31
+# https://virtocommerce.atlassian.net/browse/VCST-5041
 
 # =======================================================================================
 # The workflow collects deprecation and obsolete warnings from repos in the VirtoCommerce organization.

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.31
+# https://virtocommerce.atlassian.net/browse/VCST-5041
 name: VC cloud deployment
 
 on:

--- a/.github/workflows/deploy-module-workflows.yml
+++ b/.github/workflows/deploy-module-workflows.yml
@@ -7,7 +7,7 @@ on:
         description: 'Version to deploy'
         required: true
         type: string
-        default: 'v3.800.30'
+        default: 'v3.800.31'
 
 jobs:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.31
+# https://virtocommerce.atlassian.net/browse/VCST-5041
 name: VC deployment
 
 on:

--- a/.github/workflows/docker-image-vulnerability-process.yml
+++ b/.github/workflows/docker-image-vulnerability-process.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.31
+# https://virtocommerce.atlassian.net/browse/VCST-5041
 name: Docker image vulnerability process
 
 on:

--- a/.github/workflows/e2e-autotests.yml
+++ b/.github/workflows/e2e-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.31
+# https://virtocommerce.atlassian.net/browse/VCST-5041
 name: Common E2E tests
 
 on:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.31
+# https://virtocommerce.atlassian.net/browse/VCST-5041
 name: Common katalon tests
 
 on:

--- a/.github/workflows/get-metadata.yml
+++ b/.github/workflows/get-metadata.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.31
+# https://virtocommerce.atlassian.net/browse/VCST-5041
 name: Get metadata
 
 on:

--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.31
+# https://virtocommerce.atlassian.net/browse/VCST-5041
 name: Increment version
 
 on:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.31
+# https://virtocommerce.atlassian.net/browse/VCST-5041
 name: VC Publish docker
 
 on:

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.31
+# https://virtocommerce.atlassian.net/browse/VCST-5041
 name: VC Publish Github release and Nuget package
 
 on:

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -49,6 +49,11 @@ on:
         required: false
         type: string
         default: ''
+      databaseProviders:
+        description: 'JSON array of database providers to run the test matrix against. Any subset of: sqlserver, mysql, postgres'
+        required: false
+        type: string
+        default: '["sqlserver","mysql","postgres"]'
       frontendZipUrl:
         required: false
         type: string
@@ -109,7 +114,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        databaseProvider: [sqlserver, mysql, postgres]
+        databaseProvider: ${{ fromJSON(inputs.databaseProviders) }}
 
     env:
       GITHUB_TOKEN: ${{ secrets.envPAT }}

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -106,6 +106,11 @@ jobs:
   auto-autotests:
     runs-on: ubuntu-22.04
 
+    strategy:
+      fail-fast: false
+      matrix:
+        databaseProvider: [sqlserver, mysql, postgres]
+
     env:
       GITHUB_TOKEN: ${{ secrets.envPAT }}
 
@@ -114,7 +119,7 @@ jobs:
       uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
     - name: Docker Env Full
-      uses: VirtoCommerce/vc-github-actions/docker-env-full@master
+      uses: VirtoCommerce/vc-github-actions/docker-env-full@VCST-5041 #master
       with:
         frontendZipUrl: ${{ inputs.frontendZipUrl }}
         installModules: ${{ inputs.installModules }}
@@ -126,9 +131,10 @@ jobs:
         customModuleId: ${{ inputs.customModuleId }}
         customModuleUrl: ${{ inputs.customModuleUrl }}
         sendgridApiKey: ${{ secrets.sendgridApiKey }}
-    
+        databaseProvider: ${{ matrix.databaseProvider }}
+
     - name: Run Auto Tests
-      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@master
+      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@VCST-5041 #master
       with:
         adminPassword: ${{ inputs.adminPassword }}
         adminUsername: ${{ inputs.adminUsername }}
@@ -141,3 +147,4 @@ jobs:
         vctestingPath: ${{ inputs.vctestingPath }}
         vctestingRepo: ${{ inputs.vctestingRepo }}
         vctestingRepoBranch: ${{ inputs.vctestingRepoBranch }}
+        artifactSuffix: -${{ matrix.databaseProvider }}

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.31
+# https://virtocommerce.atlassian.net/browse/VCST-5041
 name: Auto tests
 
 on:
@@ -124,7 +124,7 @@ jobs:
       uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
     - name: Docker Env Full
-      uses: VirtoCommerce/vc-github-actions/docker-env-full@VCST-5041 #master
+      uses: VirtoCommerce/vc-github-actions/docker-env-full@master
       with:
         frontendZipUrl: ${{ inputs.frontendZipUrl }}
         installModules: ${{ inputs.installModules }}
@@ -139,7 +139,7 @@ jobs:
         databaseProvider: ${{ matrix.databaseProvider }}
 
     - name: Run Auto Tests
-      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@VCST-5041 #master
+      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@master
       with:
         adminPassword: ${{ inputs.adminPassword }}
         adminUsername: ${{ inputs.adminUsername }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.31
+# https://virtocommerce.atlassian.net/browse/VCST-5041
 name: Release workflow
 
 on:

--- a/.github/workflows/test-and-sonar.yml
+++ b/.github/workflows/test-and-sonar.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.31
+# https://virtocommerce.atlassian.net/browse/VCST-5041
 name: VC unit test and sonar scan
 
 on:

--- a/.github/workflows/ui-autotests.yml
+++ b/.github/workflows/ui-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.31
+# https://virtocommerce.atlassian.net/browse/VCST-5041
 name: Common UI tests
 
 on:

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.31
+# https://virtocommerce.atlassian.net/browse/VCST-5041
 name: Module CI
 
 on:
@@ -289,7 +289,7 @@ jobs:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.30
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.31
     with:
       installModules: 'false'
       installCustomModule: 'true'
@@ -309,7 +309,7 @@ jobs:
       && github.event_name == 'push'
       && needs.ci.outputs.deployment-folder-exists == 'true'}}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.30
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.31
     with:
       releaseSource: module
       moduleId: ${{ needs.ci.outputs.moduleId }}

--- a/workflow-templates/module-deploy.yml
+++ b/workflow-templates/module-deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.31
+# https://virtocommerce.atlassian.net/browse/VCST-5041
 name: Module deployment
 on:
   workflow_dispatch:

--- a/workflow-templates/module-release-hotfix.yml
+++ b/workflow-templates/module-release-hotfix.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.31
+# https://virtocommerce.atlassian.net/browse/VCST-5041
 name: Release hotfix
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.30
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.31
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.30    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.31    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -46,7 +46,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.30
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.31
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/workflow-templates/publish-nugets.yml
+++ b/workflow-templates/publish-nugets.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.31
+# https://virtocommerce.atlassian.net/browse/VCST-5041
 name: Publish nuget
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.30    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.31    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.30    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.31    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -29,7 +29,7 @@ jobs:
   publish-nuget:
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.30
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.31
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.31
+# https://virtocommerce.atlassian.net/browse/VCST-5041
 name: Release
 
 on:
@@ -7,6 +7,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.30    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.31    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
##Summary

Fans out the auto-autotests job into a matrix over database providers, so the same pytest suite runs against SQL Server, MySQL, and PostgreSQL on every invocation. fail-fast: false so one provider failure doesn't cancel the others.
Adds a databaseProviders workflow_call input (JSON-array string, default ["sqlserver","mysql","postgres"]) so callers can opt into a subset (e.g. ["postgres"]) and skip the 3× cost when full coverage isn't needed.
Threads databaseProvider into docker-env-full and adds artifactSuffix: -${{ matrix.databaseProvider }} to run-pytest-tests so artifact uploads from the three legs don't collide.

##Companion changes

This workflow depends on matching changes in VirtoCommerce/vc-github-actions (branch VCST-5041):

docker-env-full accepts a new databaseProvider input.
run-pytest-tests accepts a new artifactSuffix input and applies it to actions/upload-artifact.

##Test plan

 Smoke-test the input override by triggering with databaseProviders: '["postgres"]' — only one leg should run.
 Confirm a failure in one leg does not cancel the other two (fail-fast: false).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates CI to run pytest suites in a multi-database matrix, increasing workflow complexity and runtime/cost, and relies on corresponding inputs supported by `vc-github-actions` to avoid misconfiguration.
> 
> **Overview**
> **Pytest CI now runs as a database-provider matrix.** `.github/workflows/pytest-tests.yml` adds a `databaseProviders` `workflow_call` input (defaulting to SQL Server/MySQL/Postgres), configures `fail-fast: false`, threads `databaseProvider` into `docker-env-full`, and suffixes test artifacts per provider to avoid collisions.
> 
> **Workflow template/version updates.** Reusable workflow references and template headers are bumped from `v3.800.30` to `v3.800.31` (including the deploy-module-workflows default), so downstream module pipelines pick up the new matrix behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e916218dffc0e111bb714aa0cc22e34dae0136e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->