### PR TITLE
VCST-4761: Two new optional inputs (prebuiltImageArtifact, pytestMarkers) wired into the underlying actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.33
+# https://virtocommerce.atlassian.net/browse/VCST-4761
 name: VC build
 
 on:

--- a/.github/workflows/collect-deprecation-warnings.yml
+++ b/.github/workflows/collect-deprecation-warnings.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.33
+# https://virtocommerce.atlassian.net/browse/VCST-4761
 
 # =======================================================================================
 # The workflow collects deprecation and obsolete warnings from repos in the VirtoCommerce organization.

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.33
+# https://virtocommerce.atlassian.net/browse/VCST-4761
 name: VC cloud deployment
 
 on:

--- a/.github/workflows/deploy-module-workflows.yml
+++ b/.github/workflows/deploy-module-workflows.yml
@@ -7,7 +7,7 @@ on:
         description: 'Version to deploy'
         required: true
         type: string
-        default: 'v3.800.30'
+        default: 'v3.800.33'
 
 jobs:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.33
+# https://virtocommerce.atlassian.net/browse/VCST-4761
 name: VC deployment
 
 on:

--- a/.github/workflows/docker-image-vulnerability-process.yml
+++ b/.github/workflows/docker-image-vulnerability-process.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.33
+# https://virtocommerce.atlassian.net/browse/VCST-4761
 name: Docker image vulnerability process
 
 on:

--- a/.github/workflows/e2e-autotests.yml
+++ b/.github/workflows/e2e-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.33
+# https://virtocommerce.atlassian.net/browse/VCST-4761
 name: Common E2E tests
 
 on:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.33
+# https://virtocommerce.atlassian.net/browse/VCST-4761
 name: Common katalon tests
 
 on:

--- a/.github/workflows/get-metadata.yml
+++ b/.github/workflows/get-metadata.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.33
+# https://virtocommerce.atlassian.net/browse/VCST-4761
 name: Get metadata
 
 on:

--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.33
+# https://virtocommerce.atlassian.net/browse/VCST-4761
 name: Increment version
 
 on:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.33
+# https://virtocommerce.atlassian.net/browse/VCST-4761
 name: VC Publish docker
 
 on:

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.33
+# https://virtocommerce.atlassian.net/browse/VCST-4761
 name: VC Publish Github release and Nuget package
 
 on:

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -73,6 +73,11 @@ on:
         required: false
         type: string
         default: ''
+      pytestMarkers:
+        description: 'Additional pytest -m marker expression, AND-combined with each suite''s default markers. Leave empty to use defaults only.'
+        required: false
+        default: ''
+        type: string
       requiredModulesListUrl:
         description: 'The URL of the JSON file with the required modules list'
         required: false
@@ -134,7 +139,7 @@ jobs:
         prebuiltImageArtifact: ${{ inputs.prebuiltImageArtifact }}
     
     - name: Run Auto Tests
-      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@master
+      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@VCST-4761 #master
       with:
         adminPassword: ${{ inputs.adminPassword }}
         adminUsername: ${{ inputs.adminUsername }}
@@ -142,6 +147,7 @@ jobs:
         backUrl: ${{ inputs.backUrl }}
         baseUrl: ${{ inputs.baseUrl }}
         browser: ${{ inputs.browser }}
+        pytestMarkers: ${{ inputs.pytestMarkers }}
         testSecretEnvFile: ${{ secrets.testSecretEnvFile }}
         testSuites: ${{ inputs.testSuites }}
         vctestingPath: ${{ inputs.vctestingPath }}

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.33
+# https://virtocommerce.atlassian.net/browse/VCST-4761
 name: Auto tests
 
 on:
@@ -124,7 +124,7 @@ jobs:
       uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
     - name: Docker Env Full
-      uses: VirtoCommerce/vc-github-actions/docker-env-full@VCST-4761 #master
+      uses: VirtoCommerce/vc-github-actions/docker-env-full@master
       with:
         frontendZipUrl: ${{ inputs.frontendZipUrl }}
         installModules: ${{ inputs.installModules }}
@@ -139,7 +139,7 @@ jobs:
         prebuiltImageArtifact: ${{ inputs.prebuiltImageArtifact }}
     
     - name: Run Auto Tests
-      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@VCST-4761 #master
+      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@master
       with:
         adminPassword: ${{ inputs.adminPassword }}
         adminUsername: ${{ inputs.adminUsername }}

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -68,6 +68,11 @@ on:
         required: false
         type: string
         default: 'local-latest'
+      prebuiltImageArtifact:
+        description: 'Name of a workflow artifact containing a docker save tar of the platform image. When set, the action downloads and loads it instead of building or pulling, and installModules / installCustomModule / customPackagesJsonUrl must be unset.'
+        required: false
+        type: string
+        default: ''
       requiredModulesListUrl:
         description: 'The URL of the JSON file with the required modules list'
         required: false
@@ -114,7 +119,7 @@ jobs:
       uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
     - name: Docker Env Full
-      uses: VirtoCommerce/vc-github-actions/docker-env-full@master
+      uses: VirtoCommerce/vc-github-actions/docker-env-full@VCST-4761 #master
       with:
         frontendZipUrl: ${{ inputs.frontendZipUrl }}
         installModules: ${{ inputs.installModules }}
@@ -126,6 +131,7 @@ jobs:
         customModuleId: ${{ inputs.customModuleId }}
         customModuleUrl: ${{ inputs.customModuleUrl }}
         sendgridApiKey: ${{ secrets.sendgridApiKey }}
+        prebuiltImageArtifact: ${{ inputs.prebuiltImageArtifact }}
     
     - name: Run Auto Tests
       uses: VirtoCommerce/vc-github-actions/run-pytest-tests@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.33
+# https://virtocommerce.atlassian.net/browse/VCST-4761
 name: Release workflow
 
 on:

--- a/.github/workflows/test-and-sonar.yml
+++ b/.github/workflows/test-and-sonar.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.33
+# https://virtocommerce.atlassian.net/browse/VCST-4761
 name: VC unit test and sonar scan
 
 on:

--- a/.github/workflows/ui-autotests.yml
+++ b/.github/workflows/ui-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.33
+# https://virtocommerce.atlassian.net/browse/VCST-4761
 name: Common UI tests
 
 on:

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.33
+# https://virtocommerce.atlassian.net/browse/VCST-4761
 name: Module CI
 
 on:
@@ -289,7 +289,7 @@ jobs:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.30
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.33
     with:
       installModules: 'false'
       installCustomModule: 'true'
@@ -309,7 +309,7 @@ jobs:
       && github.event_name == 'push'
       && needs.ci.outputs.deployment-folder-exists == 'true'}}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.30
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.33
     with:
       releaseSource: module
       moduleId: ${{ needs.ci.outputs.moduleId }}

--- a/workflow-templates/module-deploy.yml
+++ b/workflow-templates/module-deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.33
+# https://virtocommerce.atlassian.net/browse/VCST-4761
 name: Module deployment
 on:
   workflow_dispatch:

--- a/workflow-templates/module-release-hotfix.yml
+++ b/workflow-templates/module-release-hotfix.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.33
+# https://virtocommerce.atlassian.net/browse/VCST-4761
 name: Release hotfix
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.30
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.33
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.30    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.33    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -46,7 +46,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.30
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.33
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/workflow-templates/publish-nugets.yml
+++ b/workflow-templates/publish-nugets.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.33
+# https://virtocommerce.atlassian.net/browse/VCST-4761
 name: Publish nuget
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.30    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.33    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.30    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.33    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -29,7 +29,7 @@ jobs:
   publish-nuget:
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.30
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.33
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -1,5 +1,5 @@
-# v3.800.30
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.33
+# https://virtocommerce.atlassian.net/browse/VCST-4761
 name: Release
 
 on:
@@ -7,6 +7,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.30    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.33    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes shared GitHub Actions workflows used across module CI/CD; misconfigured new inputs or version bumps could alter test environment setup or filtering and impact pipeline reliability.
> 
> **Overview**
> Bumps all reusable workflows and module templates from `v3.800.32` to `v3.800.33` (VCST-4761), including updating the module workflow deployment dispatcher default version.
> 
> Extends the reusable `pytest-tests.yml` workflow with two new optional inputs—`prebuiltImageArtifact` (to load a prebuilt platform image tar artifact) and `pytestMarkers` (to further filter suites via `pytest -m`)—and wires them through to `vc-github-actions/docker-env-full` and `run-pytest-tests`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7e59a11b8268bfafdd75f1f9e93847144492321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->