### PR TITLE
VCST-5151: Add swagger validation to module-ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
-# v3.800.35
-# https://virtocommerce.atlassian.net/browse/VCST-5063
+# v3.800.36
+# https://virtocommerce.atlassian.net/browse/VCST-5151
 name: VC build
 
 on:

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -1,5 +1,5 @@
-# v3.800.35
-# https://virtocommerce.atlassian.net/browse/VCST-5063
+# v3.800.36
+# https://virtocommerce.atlassian.net/browse/VCST-5151
 name: VC cloud deployment
 
 on:

--- a/.github/workflows/deploy-module-workflows.yml
+++ b/.github/workflows/deploy-module-workflows.yml
@@ -7,7 +7,7 @@ on:
         description: 'Version to deploy'
         required: true
         type: string
-        default: 'v3.800.35'
+        default: 'v3.800.36'
 
 jobs:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.35
-# https://virtocommerce.atlassian.net/browse/VCST-5063
+# v3.800.36
+# https://virtocommerce.atlassian.net/browse/VCST-5151
 name: VC deployment
 
 on:

--- a/.github/workflows/docker-image-vulnerability-process.yml
+++ b/.github/workflows/docker-image-vulnerability-process.yml
@@ -1,5 +1,5 @@
-# v3.800.35
-# https://virtocommerce.atlassian.net/browse/VCST-5063
+# v3.800.36
+# https://virtocommerce.atlassian.net/browse/VCST-5151
 name: Docker image vulnerability process
 
 on:

--- a/.github/workflows/e2e-autotests.yml
+++ b/.github/workflows/e2e-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.35
-# https://virtocommerce.atlassian.net/browse/VCST-5063
+# v3.800.36
+# https://virtocommerce.atlassian.net/browse/VCST-5151
 name: Common E2E tests
 
 on:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,5 @@
-# v3.800.35
-# https://virtocommerce.atlassian.net/browse/VCST-5063
+# v3.800.36
+# https://virtocommerce.atlassian.net/browse/VCST-5151
 name: Common katalon tests
 
 on:
@@ -88,7 +88,7 @@ jobs:
     - name: Docker Env
       uses: VirtoCommerce/vc-github-actions/docker-env@master
       with:
-        githubUser: ${{ env.GITHUB_ACTOR }}
+        githubUser: ${{ github.actor }}
         githubToken: ${{ env.GITHUB_TOKEN }}
         platformDockerTag: ${{ inputs.platformDockerTag }}
         platformImage: ghcr.io/virtocommerce/platform

--- a/.github/workflows/get-metadata.yml
+++ b/.github/workflows/get-metadata.yml
@@ -1,5 +1,5 @@
-# v3.800.35
-# https://virtocommerce.atlassian.net/browse/VCST-5063
+# v3.800.36
+# https://virtocommerce.atlassian.net/browse/VCST-5151
 name: Get metadata
 
 on:

--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -1,5 +1,5 @@
-# v3.800.35
-# https://virtocommerce.atlassian.net/browse/VCST-5063
+# v3.800.36
+# https://virtocommerce.atlassian.net/browse/VCST-5151
 name: Increment version
 
 on:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,5 +1,5 @@
-# v3.800.35
-# https://virtocommerce.atlassian.net/browse/VCST-5063
+# v3.800.36
+# https://virtocommerce.atlassian.net/browse/VCST-5151
 name: VC Publish docker
 
 on:

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -1,5 +1,5 @@
-# v3.800.35
-# https://virtocommerce.atlassian.net/browse/VCST-5063
+# v3.800.36
+# https://virtocommerce.atlassian.net/browse/VCST-5151
 name: VC Publish Github release and Nuget package
 
 on:

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -1,5 +1,5 @@
-# v3.800.35
-# https://virtocommerce.atlassian.net/browse/VCST-5063
+# v3.800.36
+# https://virtocommerce.atlassian.net/browse/VCST-5151
 name: Auto tests
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-# v3.800.35
-# https://virtocommerce.atlassian.net/browse/VCST-5063
+# v3.800.36
+# https://virtocommerce.atlassian.net/browse/VCST-5151
 name: Release workflow
 
 on:

--- a/.github/workflows/test-and-sonar.yml
+++ b/.github/workflows/test-and-sonar.yml
@@ -1,5 +1,5 @@
-# v3.800.35
-# https://virtocommerce.atlassian.net/browse/VCST-5063
+# v3.800.36
+# https://virtocommerce.atlassian.net/browse/VCST-5151
 name: VC unit test and sonar scan
 
 on:

--- a/.github/workflows/ui-autotests.yml
+++ b/.github/workflows/ui-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.35
-# https://virtocommerce.atlassian.net/browse/VCST-5063
+# v3.800.36
+# https://virtocommerce.atlassian.net/browse/VCST-5151
 name: Common UI tests
 
 on:

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -1,5 +1,5 @@
-# v3.800.35
-# https://virtocommerce.atlassian.net/browse/VCST-5063
+# v3.800.36
+# https://virtocommerce.atlassian.net/browse/VCST-5151
 name: Module CI
 
 on:
@@ -217,16 +217,16 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           $text = $env:PR_BODY
-          $marker = 'Required modules list URL'
-
           $url = ''
-          if ($null -ne $text -and $text.Contains($marker)) {
-            $startIndex = $text.IndexOf($marker)
-            if ($startIndex -ge 0) {
-              $slice = $text.Substring($startIndex)
-              $match = [regex]::Match($slice, 'https?://[^ )\r\n]+')
-              if ($match.Success) {
-                $url = $match.Value
+          if ($null -ne $text) {
+            $pattern = 'Required modules list URL\s*:?\s*(https?://[^\s)>\]]+)'
+            $m = [regex]::Match($text, $pattern, 'IgnoreCase')
+            if ($m.Success) {
+              $candidate = $m.Groups[1].Value.TrimEnd('.', ',', ';')
+              if ($candidate -match '\.json($|\?)') {
+                $url = $candidate
+              } else {
+                Write-Host "Candidate URL '$candidate' is not a .json file; ignoring."
               }
             }
           }
@@ -238,6 +238,20 @@ jobs:
             Write-Host "url NOT found"
             Add-Content -Path $env:GITHUB_OUTPUT -Value "url="
           }
+
+      - name: Swagger validation
+        uses: VirtoCommerce/vc-github-actions/docker-env@VCST-5054 #master
+        if: ${{ github.ref == 'refs/heads/dev' || (github.event_name == 'pull_request' && github.base_ref == 'dev') }}
+        with:
+          githubUser: ${{ github.actor }}
+          githubToken: ${{ env.GITHUB_TOKEN }}
+          installSampleData: 'false'
+          installModules: 'false'
+          installCustomModule: 'true'
+          customModuleId: ${{ steps.artifact_ver.outputs.moduleId }}
+          customModuleUrl: ${{ steps.artifactUrl.outputs.download_url }}
+          requiredModulesListUrl: ${{ steps.extract_required_modules_list_url_from_pr.outputs.url }}
+          platformImage: ghcr.io/virtocommerce/platform
 
       - name: Setup Git Credentials
         if: ${{ (github.ref == 'refs/heads/dev' && github.event_name != 'workflow_dispatch') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
@@ -289,7 +303,7 @@ jobs:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.36
     with:
       installModules: 'false'
       installCustomModule: 'true'
@@ -310,7 +324,7 @@ jobs:
       && github.event_name == 'push'
       && needs.ci.outputs.deployment-folder-exists == 'true'}}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.36
     with:
       releaseSource: module
       moduleId: ${{ needs.ci.outputs.moduleId }}

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -240,7 +240,7 @@ jobs:
           }
 
       - name: Swagger validation
-        uses: VirtoCommerce/vc-github-actions/docker-env@VCST-5054 #master
+        uses: VirtoCommerce/vc-github-actions/docker-env@master
         if: ${{ github.ref == 'refs/heads/dev' || (github.event_name == 'pull_request' && github.base_ref == 'dev') }}
         with:
           githubUser: ${{ github.actor }}

--- a/workflow-templates/module-deploy.yml
+++ b/workflow-templates/module-deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.35
-# https://virtocommerce.atlassian.net/browse/VCST-5063
+# v3.800.36
+# https://virtocommerce.atlassian.net/browse/VCST-5151
 name: Module deployment
 on:
   workflow_dispatch:

--- a/workflow-templates/module-release-hotfix.yml
+++ b/workflow-templates/module-release-hotfix.yml
@@ -1,5 +1,5 @@
-# v3.800.35
-# https://virtocommerce.atlassian.net/browse/VCST-5063
+# v3.800.36
+# https://virtocommerce.atlassian.net/browse/VCST-5151
 name: Release hotfix
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.36
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.36    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -46,7 +46,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.36
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/workflow-templates/publish-nugets.yml
+++ b/workflow-templates/publish-nugets.yml
@@ -1,5 +1,5 @@
-# v3.800.35
-# https://virtocommerce.atlassian.net/browse/VCST-5063
+# v3.800.36
+# https://virtocommerce.atlassian.net/browse/VCST-5151
 name: Publish nuget
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.36    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.36    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -29,7 +29,7 @@ jobs:
   publish-nuget:
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.36
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -1,5 +1,5 @@
-# v3.800.35
-# https://virtocommerce.atlassian.net/browse/VCST-5063
+# v3.800.36
+# https://virtocommerce.atlassian.net/browse/VCST-5151
 name: Release
 
 on:
@@ -7,6 +7,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.36    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to CI/CD workflow YAML (version pins, docker-env step, and PR URL parsing); no application runtime code.
> 
> **Overview**
> Rolls the shared reusable workflow pin from **v3.800.35** to **v3.800.36** (header comments reference **VCST-5151**) across `.github/workflows`, `workflow-templates`, and the module workflow deploy default.
> 
> The meaningful behavior change is in **module CI**: a new **Swagger validation** step runs on `dev` pushes and PRs targeting `dev`. It spins up `docker-env` with the built custom module (and optional **Required modules list URL** from the PR body), without installing the full module set or sample data. PR parsing for that URL is tightened to a regex, requires a **`.json`** link, and trims trailing punctuation.
> 
> **Katalon e2e** now passes `githubUser: ${{ github.actor }}` instead of a custom `GITHUB_ACTOR` env var.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e33c487ba55ac8a78dd7f3eb80d8204f9ac5f8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->