### PR TITLE
VCST-5155: Add a param to skip count check for indexed doc types

### DIFF
--- a/.github/workflows/e2e-autotests.yml
+++ b/.github/workflows/e2e-autotests.yml
@@ -73,6 +73,11 @@ on:
         required: false
         type: string
         default: 'true'
+      skipDocCountVerification:
+        description: 'Comma-separated document types whose post-reindex count check should be skipped (reindex still runs). Use when the seed dataset has 0 records for a type. Example: ''PickupLocation'' or ''PickupLocation,ContentFile''.'
+        required: false
+        default: ''
+        type: string
       vctestingPath:
         description: 'UI tests path'
         required: false
@@ -142,3 +147,4 @@ jobs:
         vctestingPath: ${{ inputs.vctestingPath }}
         vctestingRepo: ${{ inputs.vctestingRepo }}
         vctestingRepoBranch: ${{ inputs.vctestingRepoBranch }}
+        skipDocCountVerification: ${{ inputs.skipDocCountVerification }}

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -88,6 +88,11 @@ on:
         required: false
         type: string
         default: ''
+      skipDocCountVerification:
+        description: 'Comma-separated document types whose post-reindex count check should be skipped (reindex still runs). Use when the seed dataset has 0 records for a type. Example: ''PickupLocation'' or ''PickupLocation,ContentFile''.'
+        required: false
+        default: ''
+        type: string
       testSuites:
         description: 'Comma-separated list of suites to run. Any subset of: graphql, restapi, e2e'
         required: false
@@ -154,7 +159,7 @@ jobs:
         appInsightsInstrumentationKey: ${{ secrets.appInsightsInstrumentationKey }}
 
     - name: Run Auto Tests
-      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@master
+      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@VCST-5155 #master
       with:
         adminPassword: ${{ inputs.adminPassword }}
         adminUsername: ${{ inputs.adminUsername }}
@@ -169,3 +174,4 @@ jobs:
         vctestingRepo: ${{ inputs.vctestingRepo }}
         vctestingRepoBranch: ${{ inputs.vctestingRepoBranch }}
         artifactSuffix: -${{ matrix.databaseProvider }}
+        skipDocCountVerification: ${{ inputs.skipDocCountVerification }}

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -159,7 +159,7 @@ jobs:
         appInsightsInstrumentationKey: ${{ secrets.appInsightsInstrumentationKey }}
 
     - name: Run Auto Tests
-      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@VCST-5155 #master
+      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@master
       with:
         adminPassword: ${{ inputs.adminPassword }}
         adminUsername: ${{ inputs.adminUsername }}

--- a/.github/workflows/ui-autotests.yml
+++ b/.github/workflows/ui-autotests.yml
@@ -68,6 +68,11 @@ on:
         required: false
         type: string
         default: ''
+      skipDocCountVerification:
+        description: 'Comma-separated document types whose post-reindex count check should be skipped (reindex still runs). Use when the seed dataset has 0 records for a type. Example: ''PickupLocation'' or ''PickupLocation,ContentFile''.'
+        required: false
+        default: ''
+        type: string
       vctestingPath:
         description: 'UI tests path'
         required: false
@@ -128,3 +133,4 @@ jobs:
         vctestingPath: 'vc-testing-module'
         vctestingRepo: ${{ inputs.vctestingRepo }}
         vctestingRepoBranch: ${{ inputs.vctestingRepoBranch }}
+        skipDocCountVerification: ${{ inputs.skipDocCountVerification }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI workflow input wiring only; no application runtime or security logic changes in this repo.
> 
> **Overview**
> Adds an optional **`skipDocCountVerification`** input to the reusable **E2E**, **pytest**, and **UI** autotest workflows so callers can pass a comma-separated list of indexed document types (e.g. `PickupLocation`) where the **post-reindex count assertion** is skipped while **reindex still runs**—intended for seed data with zero records for those types.
> 
> Each workflow forwards the input to the corresponding VirtoCommerce test action (`run-e2e-tests`, `run-pytest-tests`, `run-graphql-tests`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89a866f31407d8fa628e7226aee14c06b9e964c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->