### PR TITLE
VCST-5209: Add a webhook to new repository created by workflow

### DIFF
--- a/.github/workflows/create-module-repository.yml
+++ b/.github/workflows/create-module-repository.yml
@@ -249,6 +249,27 @@ jobs:
               --field permission=${TEAMS[$TEAM]}
           done
 
+      - name: Configure pull request webhook
+        # Registers the new repo with the pull-request automation Logic App.
+        # The URL contains a signature, so it is stored as a secret rather than
+        # hardcoded. Skipped automatically when the secret is not configured.
+        # Failure here does not fail the workflow — repo setup is already complete.
+        if: ${{ env.PR_WEBHOOK_URL != '' }}
+        continue-on-error: true
+        env:
+          PR_WEBHOOK_URL: ${{ secrets.MODULE_PR_WEBHOOK_URL }}
+        run: |
+          jq -n --arg url "$PR_WEBHOOK_URL" '{
+            name: "web",
+            active: true,
+            events: ["pull_request"],
+            config: { url: $url, content_type: "json", insecure_ssl: "0" }
+          }' | gh api \
+            --method POST \
+            /repos/$REPO_FULL_NAME/hooks \
+            --input -
+          echo "Pull request webhook configured for $REPO_FULL_NAME."
+
       - name: Checkout .github (workflow templates)
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/deploy-module-workflows.yml
+++ b/.github/workflows/deploy-module-workflows.yml
@@ -102,6 +102,7 @@ jobs:
                   ,vc-module-task-management
                   ,vc-module-tax
                   ,vc-module-test-pr-hook
+                  ,vc-module-test-pr-hook1
                   ,vc-module-u-c-p
                   ,vc-module-webhooks
                   ,vc-module-white-labeling

--- a/.github/workflows/deploy-module-workflows.yml
+++ b/.github/workflows/deploy-module-workflows.yml
@@ -101,8 +101,6 @@ jobs:
                   ,vc-module-system-operations
                   ,vc-module-task-management
                   ,vc-module-tax
-                  ,vc-module-test-pr-hook
-                  ,vc-module-test-pr-hook1
                   ,vc-module-u-c-p
                   ,vc-module-webhooks
                   ,vc-module-white-labeling

--- a/.github/workflows/deploy-module-workflows.yml
+++ b/.github/workflows/deploy-module-workflows.yml
@@ -101,6 +101,7 @@ jobs:
                   ,vc-module-system-operations
                   ,vc-module-task-management
                   ,vc-module-tax
+                  ,vc-module-test-pr-hook
                   ,vc-module-u-c-p
                   ,vc-module-webhooks
                   ,vc-module-white-labeling

--- a/docs/create-module-repository.md
+++ b/docs/create-module-repository.md
@@ -9,6 +9,7 @@ Provisions a complete, standards-compliant VirtoCommerce module repository from 
 3. **Requests approval** — pauses for a designated reviewer via the `create-org-repo` environment gate.
 4. **Creates the GitHub repository** with the computed name `vc-module-{kebab}` and the requested visibility.
 5. **Configures the repository**: merge strategy (squash-only), Actions permissions (`allowed_actions=all`), team permissions, branch structure (`main` + `dev`), and branch protection rules.
+   - Registers a `pull_request` webhook pointing at the automation Logic App (skipped when `MODULE_PR_WEBHOOK_URL` is not set).
 6. **Generates module code** using the selected [vc-cli-module-template](https://github.com/VirtoCommerce/vc-cli-module-template) and commits it.
 7. **Wires up CI/CD**: copies workflow templates (`module-ci.yml`, `release.yml`, `publish-nugets.yml`, `module-release-hotfix.yml`) and writes the cloud deployment config.
 8. **Provisions SonarCloud** (public repos only): creates and binds the project to GitHub, grants project-level admin to the token user, disables Automatic Analysis, and sets the New Code definition to "Previous version".
@@ -24,6 +25,7 @@ Provisions a complete, standards-compliant VirtoCommerce module repository from 
 |--------|-------------|
 | `MODULE_REPO_MGMT_TOKEN` | PAT with `repo` and `admin:org` (team write) scopes. Used for all GitHub API calls and git operations. |
 | `SONARCLOUD_TOKEN` | SonarCloud user token with `Administer` permission on the organization. The workflow self-grants project-level admin after provisioning, so the token does not need to belong to the org owner. Required for public repos. |
+| `MODULE_PR_WEBHOOK_URL` | Full URL (including the `sig` signature) of the pull-request automation Logic App. Registered as a `pull_request` webhook on the new repo. Optional — the webhook step is skipped if this secret is not set. |
 
 ### Variables (Settings → Secrets and variables → Actions → Variables)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Optional, non-blocking workflow step plus docs; no changes to auth, app code, or rollback behavior.
> 
> **Overview**
> New module repos provisioned by **Create Module Repository** now get a **`pull_request` webhook** wired to the PR automation Logic App, so automation runs without manual hook setup.
> 
> The workflow adds **Configure pull request webhook** after team permissions: it POSTs a hook via `gh api` with JSON from `jq`, using the signed URL from the optional **`MODULE_PR_WEBHOOK_URL`** secret. The step runs only when that secret is set and uses **`continue-on-error`** so a webhook failure does not fail provisioning. **`docs/create-module-repository.md`** documents the new step and secret.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 566d11dbbd9a83ee811e2a4b0113de7c0b7a1717. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->