### PR TITLE
VCST-5244: Fix module naming when moduleName contains acronyms / multiple words

### DIFF
--- a/.github/workflows/create-module-repository.yml
+++ b/.github/workflows/create-module-repository.yml
@@ -21,7 +21,7 @@ on:
         description: 'Company namespace prefix, used for module template compiling'
         required: false
         type: string
-        default: 'VirtoCommerce'
+        default: 'Virto Commerce'
       author:
         description: 'Module author name'
         required: false

--- a/.github/workflows/create-module-repository.yml
+++ b/.github/workflows/create-module-repository.yml
@@ -88,6 +88,7 @@ jobs:
     outputs:
       repoName:        ${{ steps.names.outputs.repoName }}
       moduleId:        ${{ steps.names.outputs.moduleId }}
+      moduleNameWords: ${{ steps.names.outputs.moduleNameWords }}
       sonarProjectKey: ${{ steps.names.outputs.sonarProjectKey }}
     steps:
       - name: Validate module name
@@ -124,20 +125,37 @@ jobs:
       - name: Compute and print names
         id: names
         run: |
-          # Convert PascalCase to kebab-case, keeping acronyms intact:
-          #   - boundary between a lowercase/digit and an uppercase letter (e.g. "tM" -> "t-M")
-          #   - boundary between an acronym and a following word (e.g. "MCPServer" -> "MCP-Server")
-          # so "TestModuleMCP" -> "test-module-mcp" (not "test-module-m-c-p").
-          KEBAB=$(echo "$MODULE_NAME" \
-            | sed -E 's/([a-z0-9])([A-Z])/\1-\2/g' \
-            | sed -E 's/([A-Z]+)([A-Z][a-z])/\1-\2/g' \
-            | tr '[:upper:]' '[:lower:]')
+          # Split the PascalCase moduleName into space-separated words, treating a run
+          # of capitals (an acronym) as one word, so the module template's own pascal
+          # and kebab transforms see real word boundaries:
+          #   "TestModuleMCP" -> "Test Module MCP",  "NewsArticle" -> "News Article"
+          # This spaced form is what we pass to `dotnet new --ModuleName` below.
+          MODULE_WORDS=$(echo "$MODULE_NAME" \
+            | sed -E 's/([a-z0-9])([A-Z])/\1 \2/g' \
+            | sed -E 's/([A-Z]+)([A-Z][a-z])/\1 \2/g')
+
+          # Repo name: words joined by hyphens, lowercased -> "vc-module-test-module-mcp"
+          KEBAB=$(echo "$MODULE_WORDS" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
           REPO_NAME="vc-module-${KEBAB}"
-          MODULE_ID="${COMPANY_NAME}.${MODULE_NAME}"
+
+          # Derive MODULE_ID exactly as the module template derives its {Namespace},
+          # from the SAME spaced module name passed to `dotnet new`, so the cloudDeploy
+          # artifactKey and the module-id property match the <id> written into the
+          # generated module.manifest. The template's "pascal" form is
+          # lowercase -> title-case each whitespace word -> remove spaces, and
+          # {Namespace} = pascal(CompanyName).pascal(ModuleName).
+          pascal() {
+            echo "$1" \
+              | tr '[:upper:]' '[:lower:]' \
+              | sed -E 's/(^|[[:space:]])([a-z])/\1\u\2/g' \
+              | tr -d '[:space:]'
+          }
+          MODULE_ID="$(pascal "$COMPANY_NAME").$(pascal "$MODULE_WORDS")"
           SONAR_KEY="${GITHUB_REPOSITORY_OWNER}_${REPO_NAME}"
-          echo "repoName=${REPO_NAME}"        >> $GITHUB_OUTPUT
-          echo "moduleId=${MODULE_ID}"        >> $GITHUB_OUTPUT
-          echo "sonarProjectKey=${SONAR_KEY}" >> $GITHUB_OUTPUT
+          echo "repoName=${REPO_NAME}"            >> $GITHUB_OUTPUT
+          echo "moduleId=${MODULE_ID}"            >> $GITHUB_OUTPUT
+          echo "moduleNameWords=${MODULE_WORDS}"  >> $GITHUB_OUTPUT
+          echo "sonarProjectKey=${SONAR_KEY}"     >> $GITHUB_OUTPUT
 
           echo "### Inputs"                                                              >> $GITHUB_STEP_SUMMARY
           echo "| Parameter       | Value |"                                            >> $GITHUB_STEP_SUMMARY
@@ -177,6 +195,7 @@ jobs:
       SONAR_PROJECT_KEY: ${{ needs.summarize-inputs.outputs.sonarProjectKey }}
       VISIBILITY:       ${{ inputs.visibility }}
       MODULE_NAME:      ${{ inputs.moduleName }}
+      MODULE_NAME_WORDS: ${{ needs.summarize-inputs.outputs.moduleNameWords }}
       COMPANY_NAME:     ${{ inputs.companyName }}
       AUTHOR:           ${{ inputs.author }}
       TEMPLATE:         ${{ inputs.template }}
@@ -294,10 +313,13 @@ jobs:
 
       - name: Generate module code
         run: |
-          # Common args accepted by all module templates
+          # Common args accepted by all module templates.
+          # ModuleName is passed in space-separated form (e.g. "Test Module MCP") so the
+          # template's pascal/kebab transforms produce a correctly cased namespace and
+          # folder names; raw PascalCase would flatten to "Testmodulemcp".
           ARGS=(
             --output /tmp/generated
-            --ModuleName    "$MODULE_NAME"
+            --ModuleName    "$MODULE_NAME_WORDS"
             --CompanyName   "$COMPANY_NAME"
             --Author        "$AUTHOR"
           )

--- a/.github/workflows/create-module-repository.yml
+++ b/.github/workflows/create-module-repository.yml
@@ -124,7 +124,14 @@ jobs:
       - name: Compute and print names
         id: names
         run: |
-          KEBAB=$(echo "$MODULE_NAME" | sed 's/\([A-Z]\)/-\1/g' | sed 's/^-//' | tr '[:upper:]' '[:lower:]')
+          # Convert PascalCase to kebab-case, keeping acronyms intact:
+          #   - boundary between a lowercase/digit and an uppercase letter (e.g. "tM" -> "t-M")
+          #   - boundary between an acronym and a following word (e.g. "MCPServer" -> "MCP-Server")
+          # so "TestModuleMCP" -> "test-module-mcp" (not "test-module-m-c-p").
+          KEBAB=$(echo "$MODULE_NAME" \
+            | sed -E 's/([a-z0-9])([A-Z])/\1-\2/g' \
+            | sed -E 's/([A-Z]+)([A-Z][a-z])/\1-\2/g' \
+            | tr '[:upper:]' '[:lower:]')
           REPO_NAME="vc-module-${KEBAB}"
           MODULE_ID="${COMPANY_NAME}.${MODULE_NAME}"
           SONAR_KEY="${GITHUB_REPOSITORY_OWNER}_${REPO_NAME}"

--- a/.github/workflows/deploy-module-workflows.yml
+++ b/.github/workflows/deploy-module-workflows.yml
@@ -103,7 +103,6 @@ jobs:
                   ,vc-module-system-operations
                   ,vc-module-task-management
                   ,vc-module-tax
-                  ,vc-module-test-mcp-server
                   ,vc-module-u-c-p
                   ,vc-module-webhooks
                   ,vc-module-white-labeling

--- a/.github/workflows/deploy-module-workflows.yml
+++ b/.github/workflows/deploy-module-workflows.yml
@@ -103,6 +103,7 @@ jobs:
                   ,vc-module-system-operations
                   ,vc-module-task-management
                   ,vc-module-tax
+                  ,vc-module-test-mcp-server
                   ,vc-module-u-c-p
                   ,vc-module-webhooks
                   ,vc-module-white-labeling

--- a/deprecated-residual-callers.md
+++ b/deprecated-residual-callers.md
@@ -1,0 +1,104 @@
+# Residual callers of deprecated actions / workflows
+
+Active (non-commented) references across all 211 non-deploy-list org repos + internal sources. `self-deprecated` = the caller itself moved to `deprecated/`; `archived` = caller repo archived (wont run); `LIVE-pinned` = active caller on an immutable version tag (safe until it bumps); `LIVE-MUTABLE` = active caller on `@master`/branch (**breaks on merge to default branch**).
+
+## Deprecated actions (vc-github-actions)
+
+| Action | Caller repo | Caller workflow | Ref | Class |
+|---|---|---|---|---|
+| `build-theme` | vc-composer-theme | main.yml | `@master` | LIVE-MUTABLE |
+| `build-theme` | vc-demo-theme-b2b | autotest.yml | `@master` | archived |
+| `build-theme` | vc-demo-theme-default | main.yml | `@master` | archived |
+| `build-theme` | vc-demo-theme-b2b | main.yml | `@master` | archived |
+| `build-theme` | vc-theme-b2b | main.yml | `@master` | archived |
+| `build-theme` | vc-theme-default | main.yml | `@master` | archived |
+| `build-theme` | vc-theme-material | main.yml | `@master` | archived |
+| `build-theme` | vc-theme-material | release-alpha.yml | `@master` | archived |
+| `build-vue-theme` | vc-marketplace-theme | main.yml | `@master` | LIVE-MUTABLE |
+| `check-acr-repos-size-limit` | vc-github-actions | acr-size-limit.yaml | `@master` | self-deprecated |
+| `cloud-get-deploy-param` | — | — | — | no callers |
+| `deploy-workflow` | vc-github-actions | deploy-sdk.yml | `@master` | self-deprecated |
+| `deploy-workflow` | vc-github-actions | deploy.yml | `@master` | self-deprecated |
+| `docker-check-modules` | vc-demo-theme-b2b | autotest.yml | `@master` | archived |
+| `docker-install-modules` | vc-demo-theme-b2b | autotest.yml | `@master` | archived |
+| `docker-install-sampledata` | — | — | — | no callers |
+| `docker-install-theme` | vc-demo-theme-b2b | autotest.yml | `@master` | archived |
+| `docker-restore-dump` | vc-demo-theme-b2b | autotest.yml | `@master` | archived |
+| `docker-start-environment` | vc-demo-theme-b2b | autotest.yml | `@master` | archived |
+| `docker-validate-swagger` | — | — | — | no callers |
+| `generate-dashboard` | vc-github-actions | dashboard.yml | `@master` | self-deprecated |
+| `generate-dashboard-durations` | vc-github-actions | dashboard.yml | `@master` | self-deprecated |
+| `katalon-studio-github-action` | vc-demo-theme-b2b | autotest.yml | `@master` | archived |
+| `katalon-studio-github-action` | .github | e2e.yml | `@master` | self-deprecated |
+| `katalon-studio-github-action` | vc-module-experience-api | main_postman.yml | `@master` | archived |
+| `katalon-studio-github-action` | vc-github-actions | katalon-report.yml | `@master` | self-deprecated |
+| `katalon-studio-github-action` | vc-github-actions | katalon.yml | `@master` | self-deprecated |
+| `katalon-studio-github-action` | vc-github-actions | suiteDebug.yml | `@master` | self-deprecated |
+| `katalon-studio-github-action` | vc-quality-gate-katalon | demo_workflow.yml | `@master` | LIVE-MUTABLE |
+| `pr-body-get-link` | vc-storefront | pr-deploy.yml | `@master` | LIVE-MUTABLE |
+| `publish-katalon-report` | .github | e2e.yml | `@master` | self-deprecated |
+| `publish-katalon-report` | vc-github-actions | katalon-report.yml | `@master` | self-deprecated |
+| `publish-katalon-report` | vc-github-actions | katalon.yml | `@master` | self-deprecated |
+| `publish-katalon-report` | vc-github-actions | suiteDebug.yml | `@master` | self-deprecated |
+| `publish-katalon-report` | vc-quality-gate-katalon | demo_workflow.yml | `@master` | LIVE-MUTABLE |
+| `publish-theme` | vc-composer-theme | main.yml | `@master` | LIVE-MUTABLE |
+| `publish-theme` | vc-demo-theme-default | main.yml | `@master` | archived |
+| `publish-theme` | vc-demo-theme-b2b | main.yml | `@master` | archived |
+| `publish-theme` | vc-marketplace-theme | main.yml | `@master` | LIVE-MUTABLE |
+| `publish-theme` | vc-theme-b2b | main.yml | `@master` | archived |
+| `publish-theme` | vc-theme-default | main.yml | `@master` | archived |
+| `publish-theme` | vc-theme-material | main.yml | `@master` | archived |
+| `publish-theme` | vc-theme-material | release-alpha.yml | `@master` | archived |
+| `run-e2e-tests` | .github | e2e-autotests.yml | `@master` | self-deprecated |
+| `run-graphql-tests` | .github | ui-autotests.yml | `@master` | self-deprecated |
+| `set-version-up` | — | — | — | no callers |
+| `sonar-theme` | vc-demo-xapi-app | main.yml | `@master` | archived |
+| `sonar-theme` | vc-demo-theme-default | main.yml | `@master` | archived |
+| `sonar-theme` | vc-demo-theme-b2b | main.yml | `@master` | archived |
+| `sonar-theme` | vc-odt-mpa-theme | main.yml | `@master` | archived |
+| `sonar-theme` | vc-theme-b2b | main.yml | `@master` | archived |
+| `sonar-theme` | vc-theme-default | main.yml | `@master` | archived |
+| `sonar-theme` | vc-theme-material | main.yml | `@master` | archived |
+| `sonar-theme` | vc-theme-material | release-alpha.yml | `@master` | archived |
+| `update-deploy-config` | vc-github-actions | deploy-cloud-config-deployment.yml | `@master` | self-deprecated |
+| `update-deploy-config` | vc-github-actions | deploy-config-deployment.yml | `@master` | self-deprecated |
+| `update-virtocommerce-docs-2` | vc-github-actions | virtocommerce-docs-2.yml | `@master` | self-deprecated |
+| `update-virtocommercecom` | vc-module-Authorize.Net | module-ci.yml | `@master` | archived |
+| `update-virtocommercecom` | vc-module-ai-document-parser | module-ci.yml | `@master` | LIVE-MUTABLE |
+| `update-virtocommercecom` | vc-module-metadata | module-ci.yml | `@master` | archived |
+| `update-virtocommercecom` | vc-module-quote-experience-api | module-ci.yml | `@master` | archived |
+| `update-webhook-configuration` | vc-github-actions | jira-pr-webhook-update.yaml | `@master` | self-deprecated |
+| `validate-swagger` | — | — | — | no callers |
+
+## Deprecated reusable workflows (.github)
+
+| Workflow | Caller repo | Caller workflow | Ref | Class |
+|---|---|---|---|---|
+| `e2e-autotests.yml` | vc-testing-module | e2e-tests-docker.yml | `@v3.800.23` | LIVE-pinned |
+| `e2e.yml` | vc-ci-test | module-ci-common.yml | `@v3.800.24` | LIVE-pinned |
+| `e2e.yml` | vc-dev-training | module-ci.yml | `@v3.800.22` | LIVE-pinned |
+| `e2e.yml` | vc-github-actions | Katalon_new.yml | `@v3.800.37` | self-deprecated |
+| `e2e.yml` | vc-module-Authorize.Net | module-ci.yml | `@v3.200.20` | archived |
+| `e2e.yml` | vc-module-ai-document-parser | module-ci.yml | `@v3.200.35` | LIVE-pinned |
+| `e2e.yml` | vc-module-catalog-export-import | module-ci.yml | `@v3.200.36` | archived |
+| `e2e.yml` | vc-module-environments-compare | module-ci.yml | `@v3.800.17` | LIVE-pinned |
+| `e2e.yml` | vc-github-actions | katalon_platform_test.yml | `@main` | self-deprecated |
+| `e2e.yml` | vc-module-marketing-campaigns | module-ci.yml | `@v3.800.25` | LIVE-pinned |
+| `e2e.yml` | vc-module-metadata | module-ci.yml | `@v3.200.20` | archived |
+| `e2e.yml` | vc-module-opentelemetry | module-ci.yml | `@v3.800.25` | LIVE-pinned |
+| `e2e.yml` | vc-module-one-shell-app | module-ci.yml | `@v3.800.24` | LIVE-pinned |
+| `e2e.yml` | vc-module-quote-experience-api | module-ci.yml | `@v3.200.20` | archived |
+| `e2e.yml` | vc-module-test-module | module-ci.yml | `@v3.800.26` | LIVE-pinned |
+| `e2e.yml` | vc-module-shopify-taxonomy | module-ci.yml | `@v3.800.12` | LIVE-pinned |
+| `e2e.yml` | vc-module-ui-migration | module-ci.yml | `@v3.800.16` | LIVE-pinned |
+| `get-metadata.yml` | — | — | — | no callers |
+| `increment-version.yml` | — | — | — | no callers |
+| `ui-autotests.yml` | vc-ci-test | module-ci-common.yml | `@v3.800.24` | LIVE-pinned |
+| `ui-autotests.yml` | vc-dev-training | module-ci.yml | `@v3.800.22` | LIVE-pinned |
+| `ui-autotests.yml` | vc-module-environments-compare | module-ci.yml | `@v3.800.17` | LIVE-pinned |
+| `ui-autotests.yml` | vc-module-marketing-campaigns | module-ci.yml | `@v3.800.25` | LIVE-pinned |
+| `ui-autotests.yml` | vc-module-opentelemetry | module-ci.yml | `@v3.800.25` | LIVE-pinned |
+| `ui-autotests.yml` | vc-module-one-shell-app | module-ci.yml | `@v3.800.24` | LIVE-pinned |
+| `ui-autotests.yml` | vc-module-test-module | module-ci.yml | `@v3.800.26` | LIVE-pinned |
+| `ui-autotests.yml` | vc-module-ui-migration | module-ci.yml | `@v3.800.16` | LIVE-pinned |
+| `ui-autotests.yml` | vc-testing-module | graphql-tests-docker.yml | `@v3.800.23` | LIVE-pinned |


### PR DESCRIPTION

Problem
create-module-repository.yml mangled module names that contain acronyms or multiple words. For input TestModuleMCP it produced repo vc-module-test-module-m-c-p, and the module id / namespace flattened to Testmodulemcp. The workflow's MODULE_ID (used for the cloudDeploy artifactKey and the module-id custom property) was also computed from raw inputs and didn't match the <id> the template actually writes into module.manifest, breaking deploy resolution.

Changes
Acronym-aware kebab repo name — split on real word boundaries (lowercase/digit→upper, and acronym→word) so TestModuleMCP → vc-module-test-module-mcp.
Aligned MODULE_ID with the template — derive it via the same pascal(CompanyName).pascal(ModuleName) transform the template uses for {Namespace}, so the artifactKey, module-id property, and generated module.manifest <id> all agree.
Pass a space-separated module name to dotnet new — feeding the template real word boundaries yields a correctly cased namespace (VirtoCommerce.TestModuleMcp) and folder names instead of Testmodulemcp.
companyName default → Virto Commerce (with space) to match the template's pascal transform (VirtoCommerce); the prior no-space value produced Virtocommerce.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provisioning logic for new module repos (IDs, artifact keys, template output); wrong edge cases in sed/pascal could still mis-name repos, but scope is limited to the create-module-repository workflow.
> 
> **Overview**
> Fixes **create-module-repository** so multi-word and acronym PascalCase names (e.g. `TestModuleMCP`) no longer produce wrong repo slugs, flattened namespaces, or deploy IDs that disagree with the generated `module.manifest`.
> 
> The **Compute and print names** step now splits `moduleName` into space-separated words (acronym-aware), builds the repo as `vc-module-{kebab}` from those words, computes **`moduleId`** with the same `pascal(CompanyName).pascal(ModuleName)` logic as the dotnet template, and exposes **`moduleNameWords`** as a job output. **Generate module code** passes that spaced name to `dotnet new --ModuleName` instead of raw PascalCase.
> 
> Also adds **`deprecated-residual-callers.md`**, an inventory of org repos still referencing deprecated GitHub actions/workflows (LIVE-MUTABLE vs pinned vs archived).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8ac0500e432f7890d1c187689067efbe3670761. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->