### PR TITLE
VCST-5246: Move swagger validation to distinct job in module-ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
-# v3.800.38
-# https://virtocommerce.atlassian.net/browse/VCST-4492
+# v3.800.39
+# https://virtocommerce.atlassian.net/browse/VCST-5246
 name: VC build
 
 on:

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -1,5 +1,5 @@
-# v3.800.38
-# https://virtocommerce.atlassian.net/browse/VCST-4492
+# v3.800.39
+# https://virtocommerce.atlassian.net/browse/VCST-5246
 name: VC cloud deployment
 
 on:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.38
-# https://virtocommerce.atlassian.net/browse/VCST-4492
+# v3.800.39
+# https://virtocommerce.atlassian.net/browse/VCST-5246
 name: VC deployment
 
 on:

--- a/.github/workflows/docker-image-vulnerability-process.yml
+++ b/.github/workflows/docker-image-vulnerability-process.yml
@@ -1,5 +1,5 @@
-# v3.800.38
-# https://virtocommerce.atlassian.net/browse/VCST-4492
+# v3.800.39
+# https://virtocommerce.atlassian.net/browse/VCST-5246
 name: Docker image vulnerability process
 
 on:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,5 +1,5 @@
-# v3.800.38
-# https://virtocommerce.atlassian.net/browse/VCST-4492
+# v3.800.39
+# https://virtocommerce.atlassian.net/browse/VCST-5246
 name: VC Publish docker
 
 on:

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -1,5 +1,5 @@
-# v3.800.38
-# https://virtocommerce.atlassian.net/browse/VCST-4492
+# v3.800.39
+# https://virtocommerce.atlassian.net/browse/VCST-5246
 name: VC Publish Github release and Nuget package
 
 on:

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -142,7 +142,7 @@ jobs:
       uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
     - name: Docker Env Full
-      uses: VirtoCommerce/vc-github-actions/docker-env-full@master
+      uses: VirtoCommerce/vc-github-actions/docker-env-full@VCST-5246 #master
       with:
         frontendZipUrl: ${{ inputs.frontendZipUrl }}
         installModules: ${{ inputs.installModules }}
@@ -159,7 +159,7 @@ jobs:
         appInsightsInstrumentationKey: ${{ secrets.appInsightsInstrumentationKey }}
 
     - name: Run Auto Tests
-      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@master
+      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@VCST-5246 #master
       with:
         adminPassword: ${{ inputs.adminPassword }}
         adminUsername: ${{ inputs.adminUsername }}

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -142,7 +142,7 @@ jobs:
       uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
     - name: Docker Env Full
-      uses: VirtoCommerce/vc-github-actions/docker-env-full@VCST-5246 #master
+      uses: VirtoCommerce/vc-github-actions/docker-env-full@master
       with:
         frontendZipUrl: ${{ inputs.frontendZipUrl }}
         installModules: ${{ inputs.installModules }}
@@ -159,7 +159,7 @@ jobs:
         appInsightsInstrumentationKey: ${{ secrets.appInsightsInstrumentationKey }}
 
     - name: Run Auto Tests
-      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@VCST-5246 #master
+      uses: VirtoCommerce/vc-github-actions/run-pytest-tests@master
       with:
         adminPassword: ${{ inputs.adminPassword }}
         adminUsername: ${{ inputs.adminUsername }}

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -1,5 +1,5 @@
-# v3.800.38
-# https://virtocommerce.atlassian.net/browse/VCST-4492
+# v3.800.39
+# https://virtocommerce.atlassian.net/browse/VCST-5246
 name: Auto tests
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-# v3.800.38
-# https://virtocommerce.atlassian.net/browse/VCST-4492
+# v3.800.39
+# https://virtocommerce.atlassian.net/browse/VCST-5246
 name: Release workflow
 
 on:

--- a/.github/workflows/test-and-sonar.yml
+++ b/.github/workflows/test-and-sonar.yml
@@ -1,5 +1,5 @@
-# v3.800.38
-# https://virtocommerce.atlassian.net/browse/VCST-4492
+# v3.800.39
+# https://virtocommerce.atlassian.net/browse/VCST-5246
 name: VC unit test and sonar scan
 
 on:

--- a/deprecated/workflows/e2e-autotests.yml
+++ b/deprecated/workflows/e2e-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.38
-# https://virtocommerce.atlassian.net/browse/VCST-4492
+# v3.800.39
+# https://virtocommerce.atlassian.net/browse/VCST-5246
 name: Common E2E tests
 
 on:

--- a/deprecated/workflows/e2e.yml
+++ b/deprecated/workflows/e2e.yml
@@ -1,5 +1,5 @@
-# v3.800.38
-# https://virtocommerce.atlassian.net/browse/VCST-4492
+# v3.800.39
+# https://virtocommerce.atlassian.net/browse/VCST-5246
 name: Common katalon tests
 
 on:

--- a/deprecated/workflows/get-metadata.yml
+++ b/deprecated/workflows/get-metadata.yml
@@ -1,5 +1,5 @@
-# v3.800.38
-# https://virtocommerce.atlassian.net/browse/VCST-4492
+# v3.800.39
+# https://virtocommerce.atlassian.net/browse/VCST-5246
 name: Get metadata
 
 on:

--- a/deprecated/workflows/increment-version.yml
+++ b/deprecated/workflows/increment-version.yml
@@ -1,5 +1,5 @@
-# v3.800.38
-# https://virtocommerce.atlassian.net/browse/VCST-4492
+# v3.800.39
+# https://virtocommerce.atlassian.net/browse/VCST-5246
 name: Increment version
 
 on:

--- a/deprecated/workflows/ui-autotests.yml
+++ b/deprecated/workflows/ui-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.38
-# https://virtocommerce.atlassian.net/browse/VCST-4492
+# v3.800.39
+# https://virtocommerce.atlassian.net/browse/VCST-5246
 name: Common UI tests
 
 on:

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -1,5 +1,5 @@
-# v3.800.38
-# https://virtocommerce.atlassian.net/browse/VCST-4492
+# v3.800.39
+# https://virtocommerce.atlassian.net/browse/VCST-5246
 name: Module CI
 
 on:
@@ -72,7 +72,7 @@ jobs:
             node-version: '24'
 
       - name: Set up Java 17
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -82,7 +82,7 @@ jobs:
         run: |
           echo "RELEASE_STATUS=true" >> $GITHUB_ENV
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -254,20 +254,6 @@ jobs:
             Add-Content -Path $env:GITHUB_OUTPUT -Value "url="
           }
 
-      - name: Swagger validation
-        uses: VirtoCommerce/vc-github-actions/docker-env@master
-        if: ${{ github.ref == 'refs/heads/dev' || (github.event_name == 'pull_request' && github.base_ref == 'dev') }}
-        with:
-          githubUser: ${{ github.actor }}
-          githubToken: ${{ env.GITHUB_TOKEN }}
-          installSampleData: 'false'
-          installModules: 'false'
-          installCustomModule: 'true'
-          customModuleId: ${{ steps.artifact_ver.outputs.moduleId }}
-          customModuleUrl: ${{ steps.artifactUrl.outputs.download_url }}
-          requiredModulesListUrl: ${{ steps.extract_required_modules_list_url_from_pr.outputs.url }}
-          platformImage: ghcr.io/virtocommerce/platform
-
       - name: Setup Git Credentials
         if: ${{ (github.ref == 'refs/heads/dev' && github.event_name != 'workflow_dispatch') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
         uses: VirtoCommerce/vc-github-actions/setup-git-credentials-github@master
@@ -320,7 +306,7 @@ jobs:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.38
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.39
     with:
       installModules: 'false'
       installCustomModule: 'true'
@@ -336,6 +322,32 @@ jobs:
       testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
       sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
 
+  swagger-validation:
+    if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
+        (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
+    needs: ci
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Install VirtoCommerce.GlobalTool
+        uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
+
+      - name: Swagger validation
+        uses: VirtoCommerce/vc-github-actions/docker-env@master
+        with:
+          appInsightsInstrumentationKey: ${{ secrets.E2E_APPINSIGHTSINSTRUMENTATIONKEY }}
+          githubUser: ${{ github.actor }}
+          githubToken: ${{ secrets.REPO_TOKEN }}
+          installSampleData: 'false'
+          installModules: 'false'
+          installCustomModule: 'true'
+          customModuleId: ${{ needs.ci.outputs.moduleId }}
+          customModuleUrl: ${{ needs.ci.outputs.artifactUrl }}
+          requiredModulesListUrl: ${{ needs.ci.outputs.requiredModulesListUrl }}
+          platformImage: ghcr.io/virtocommerce/platform
+
   deploy-cloud:
     if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
       && github.event_name == 'push'
@@ -345,7 +357,7 @@ jobs:
     permissions:
       contents: read
       deployments: write
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.38
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.39
     with:
       releaseSource: module
       moduleId: ${{ needs.ci.outputs.moduleId }}
@@ -353,4 +365,4 @@ jobs:
       moduleBlob: ${{ needs.ci.outputs.blobId }}
       jiraKeys: ${{ needs.ci.outputs.jira-keys }}
       matrix: '{"include":${{ needs.ci.outputs.matrix }}}'
-    secrets: inherit # zizmor: ignore[secrets-inherit] deploy-cloud.yml@v3.800.38 reads undeclared org secrets; explicit passing needs a new release + tag bump
+    secrets: inherit # zizmor: ignore[secrets-inherit] deploy-cloud.yml@v3.800.39 reads undeclared org secrets; explicit passing needs a new release + tag bump

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -323,8 +323,8 @@ jobs:
       sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
 
   swagger-validation:
-    if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
-        (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
+    if: ${{ github.ref == 'refs/heads/dev' ||
+        (github.event_name == 'pull_request' && github.base_ref == 'dev') }}
     needs: ci
     runs-on: ubuntu-24.04
     permissions:
@@ -349,10 +349,16 @@ jobs:
           platformImage: ghcr.io/virtocommerce/platform
 
   deploy-cloud:
-    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+    # always() + explicit result checks: swagger-validation only runs on the dev flow, so it is
+    # 'skipped' on master/main pushes. Deploy when swagger passed (dev) or was skipped (master/main),
+    # but block when it failed (e.g. a direct push to dev that bypassed branch protection).
+    if: ${{ always()
+      && needs.ci.result == 'success'
+      && (needs.swagger-validation.result == 'success' || needs.swagger-validation.result == 'skipped')
+      && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
       && github.event_name == 'push'
       && needs.ci.outputs.deployment-folder-exists == 'true'}}
-    needs: ci
+    needs: [ci, swagger-validation]
     # deploy-cloud.yml writes deployment status via GITHUB_TOKEN; rest uses inherited PATs.
     permissions:
       contents: read

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -260,6 +260,10 @@ jobs:
         with:
           githubToken: ${{ secrets.REPO_TOKEN }}
 
+      # NOTE: This step is intentionally NOT gated on swagger-validation. In the normal flow swagger
+      # runs (and must pass) on the PR into dev before code is merged, so anything reaching dev/master/main
+      # is already validated. The only uncovered case is a direct push that bypasses the PR; that is closed
+      # by the branch protection rule on dev (required swagger check + no direct pushes), not in-workflow.
       - name: Publish Manifest
         if: ${{ (github.ref == 'refs/heads/dev' && github.event_name != 'workflow_dispatch') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
         uses: VirtoCommerce/vc-github-actions/publish-manifest@master

--- a/workflow-templates/module-deploy.yml
+++ b/workflow-templates/module-deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.38
-# https://virtocommerce.atlassian.net/browse/VCST-4492
+# v3.800.39
+# https://virtocommerce.atlassian.net/browse/VCST-5246
 name: Module deployment
 on:
   workflow_dispatch:

--- a/workflow-templates/module-release-hotfix.yml
+++ b/workflow-templates/module-release-hotfix.yml
@@ -1,5 +1,5 @@
-# v3.800.38
-# https://virtocommerce.atlassian.net/browse/VCST-4492
+# v3.800.39
+# https://virtocommerce.atlassian.net/browse/VCST-5246
 name: Release hotfix
 
 on:
@@ -17,12 +17,12 @@ permissions:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.38
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.39
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.38    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.39    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -55,7 +55,7 @@ jobs:
       pull-requests: write
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.38
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.39
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/workflow-templates/publish-nugets.yml
+++ b/workflow-templates/publish-nugets.yml
@@ -1,5 +1,5 @@
-# v3.800.38
-# https://virtocommerce.atlassian.net/browse/VCST-4492
+# v3.800.39
+# https://virtocommerce.atlassian.net/browse/VCST-5246
 name: Publish nuget
 
 on:
@@ -17,12 +17,12 @@ permissions:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.38    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.39    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.38    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.39    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -37,7 +37,7 @@ jobs:
       pull-requests: write
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.38
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.39
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -1,5 +1,5 @@
-# v3.800.38
-# https://virtocommerce.atlassian.net/browse/VCST-4492
+# v3.800.39
+# https://virtocommerce.atlassian.net/browse/VCST-5246
 name: Release
 
 on:
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.38    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.39    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes deploy gating and CI job topology for module repos; misconfigured `always()`/`needs` could block or allow cloud deploy incorrectly, though logic explicitly handles skipped swagger on master/main.
> 
> **Overview**
> **Swagger validation** is no longer a step inside the `ci` job in `module-ci.yml`. It runs as its own **`swagger-validation`** job (dev pushes and PRs into `dev`), using CI artifact outputs and `docker-env` with `REPO_TOKEN` / App Insights secrets.
> 
> **Cloud deploy** now **`needs: [ci, swagger-validation]`** and uses `always()` so deployment proceeds when CI succeeds and swagger either **passed** (dev) or **was skipped** (master/main); a failed swagger job blocks deploy. Comments note that **Publish Manifest** stays ungated in-workflow because PR checks already enforce swagger on the normal dev path.
> 
> Reusable workflow pins and header versions are bumped **v3.800.38 → v3.800.39** (VCST-5246) across `.github/workflows`, `workflow-templates`, and deprecated workflows. `module-ci` also pins **`actions/checkout` to v6.0.3** and **`setup-java` to v5.2.0** (down from v7 / v5.3.0 on that template).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8be4119e558715f6824e3b79eece54cf26e45d70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->