### PR TITLE
Update branch protection rules

### DIFF
--- a/.github/workflows/create-module-repository.yml
+++ b/.github/workflows/create-module-repository.yml
@@ -452,7 +452,8 @@ jobs:
                 "SonarCloud Code Analysis",
                 "auto-tests / auto-autotests (mysql)",
                 "auto-tests / auto-autotests (postgres)",
-                "auto-tests / auto-autotests (sqlserver)"
+                "auto-tests / auto-autotests (sqlserver)",
+                "swagger-validation"
               ]
             },
             "enforce_admins": false,

--- a/.github/workflows/deploy-module-workflows.yml
+++ b/.github/workflows/deploy-module-workflows.yml
@@ -39,7 +39,7 @@ jobs:
                   ,vc-module-bulk-actions
                   ,vc-module-cart
                   ,vc-module-catalog
-                  ,vc-module-catalog-csv-import
+                  ,vc-module-catalog-csv-export-import
                   ,vc-module-catalog-personalization
                   ,vc-module-catalog-publishing
                   ,vc-module-content
@@ -104,7 +104,7 @@ jobs:
                   ,vc-module-system-operations
                   ,vc-module-task-management
                   ,vc-module-tax
-                  ,vc-module-u-c-p
+                  ,vc-module-ucp
                   ,vc-module-webhooks
                   ,vc-module-white-labeling
                   ,vc-module-x-api

--- a/scripts/Update-ModuleBranchProtection.ps1
+++ b/scripts/Update-ModuleBranchProtection.ps1
@@ -1,31 +1,26 @@
 #requires -Version 7.0
 <#
 .SYNOPSIS
-    Swap required status checks on protected branches of existing module repos.
+    Declaratively enforce the required status checks on protected branches of
+    existing module repos.
 
 .DESCRIPTION
-    Mirrors the change applied to new repos by
-    .github/workflows/create-module-repository.yml (the "Protect branches" step):
-    replaces the old required status checks with the configured new ones on
-    `dev`. Any of the configured old checks that are present get
-    removed; any of the new checks that are missing get added.
+    Forces the required status checks to be EXACTLY -DesiredChecks on every
+    targeted branch, regardless of what each repo currently has: missing checks
+    are added and any check not in the list is removed. -DesiredChecks defaults
+    to the canonical policy in
+    .github/workflows/create-module-repository.yml (the "Protect branches"
+    step), so a bare run converges every repo to that set.
 
-    Read-modify-write: fetches each branch's current protection, updates only the
-    contexts list, and PUTs it back. Other settings (reviews, enforce_admins,
-    restrictions, etc.) are preserved as-is.
+    Read-modify-write: fetches each branch's current protection, replaces only
+    the status-check contexts list, and PUTs it back. All other settings
+    (reviews, enforce_admins, restrictions, etc.) are preserved as-is.
 
     With -AddIfMissing, the script also creates protection on branches that
-    exist but have no protection rules at all, mirroring the default policy
-    applied by the create-module-repository workflow. Branches that don't
-    exist are still skipped.
-
-    Add-only (no removal): to just add one or more checks without removing
-    anything, pass an empty -OldChecks, list only the new check(s) in
-    -NewChecks, and use -AddIfMissing. Existing contexts are read and
-    preserved automatically, so -NewChecks need not repeat them. Because no
-    old check is present to trigger the swap path, -AddIfMissing is required
-    for the addition to apply (note it will also create protection from
-    scratch on unprotected branches).
+    exist but have no protection rules at all (mirroring the default policy
+    applied by the create-module-repository workflow), and enables status-check
+    enforcement on branches that are protected but have it switched off.
+    Branches that don't exist are still skipped.
 
 .EXAMPLE
     pwsh ./Update-ModuleBranchProtection.ps1 -WhatIf
@@ -33,27 +28,27 @@
     pwsh ./Update-ModuleBranchProtection.ps1 -Repos vc-module-news,vc-module-cart
 
 .EXAMPLE
-    # Add a single check without removing any existing ones.
+    # Converge to an explicit custom set instead of the canonical default.
     pwsh ./Update-ModuleBranchProtection.ps1 `
-        -OldChecks @() `
-        -NewChecks 'swagger-validation' `
-        -AddIfMissing -WhatIf
+        -DesiredChecks 'ci', 'SonarCloud Code Analysis', 'swagger-validation' `
+        -WhatIf
 #>
 [CmdletBinding(SupportsShouldProcess = $true)]
 param(
     [string]$Org = 'VirtoCommerce',
     [string[]]$Repos,
     [string[]]$Branches = @('dev'),
-    [string[]]$OldChecks = @(
-        'module-katalon-tests / e2e-tests',
-        'UI-auto-tests / ui-autotests',
-        'UI-auto-tests / dry-run',
-        'auto-tests / auto-autotests'
-    ),
-    [string[]]$NewChecks = @(
+    # The required checks to enforce, verbatim: any check not listed is removed
+    # from each branch. Default mirrors the canonical policy in
+    # .github/workflows/create-module-repository.yml.
+    [string[]]$DesiredChecks = @(
+        'license/cla',
+        'ci',
+        'SonarCloud Code Analysis',
         'auto-tests / auto-autotests (mysql)',
         'auto-tests / auto-autotests (postgres)',
-        'auto-tests / auto-autotests (sqlserver)'
+        'auto-tests / auto-autotests (sqlserver)',
+        'swagger-validation'
     ),
     [switch]$AddIfMissing,
     # PAT with repo admin on the target repos. If omitted, falls back to existing
@@ -94,15 +89,11 @@ function Get-Enabled {
 # Default protection policy for newly-created protection. Mirrors the
 # "Protect branches" step in .github/workflows/create-module-repository.yml.
 function New-DefaultProtectionPayload {
-    param([string[]]$NewChecks)
+    param([string[]]$Contexts)
     return [ordered]@{
         required_status_checks = [ordered]@{
             strict   = $false
-            contexts = @(
-                'license/cla',
-                'ci',
-                'SonarCloud Code Analysis'
-            ) + $NewChecks
+            contexts = @($Contexts)
         }
         enforce_admins                = $false
         required_pull_request_reviews = [ordered]@{
@@ -173,8 +164,7 @@ function Update-BranchProtection {
     param(
         [string]$RepoFull,
         [string]$Branch,
-        [string[]]$OldChecks,
-        [string[]]$NewChecks,
+        [string[]]$DesiredChecks,
         [bool]$AddIfMissing
     )
 
@@ -186,7 +176,7 @@ function Update-BranchProtection {
             if (-not $AddIfMissing) {
                 return [pscustomobject]@{ Status = 'SKIP'; Reason = 'no protection (use -AddIfMissing to create)' }
             }
-            $payload = New-DefaultProtectionPayload -NewChecks $NewChecks
+            $payload = New-DefaultProtectionPayload -Contexts $DesiredChecks
             $action  = "create protection -> [$($payload.required_status_checks.contexts -join ', ')]"
             return Invoke-PutProtection -RepoFull $RepoFull -Branch $Branch -Payload $payload -Action $action
         }
@@ -203,27 +193,21 @@ function Update-BranchProtection {
             return [pscustomobject]@{ Status = 'SKIP'; Reason = 'no required_status_checks (use -AddIfMissing to add)' }
         }
         # Branch is protected but status-check enforcement is off; synthesize an
-        # empty block so the add-new-check path below enables it without
-        # touching the rest of the existing protection.
+        # empty block so the logic below enables it with the desired checks
+        # without touching the rest of the existing protection.
         $rsc = [pscustomobject]@{ strict = $false; contexts = @() }
     }
 
-    $contexts   = @($rsc.contexts)
-    $toRemove   = @($OldChecks  | Where-Object { $contexts -contains $_ })
-    $toAdd      = @($NewChecks  | Where-Object { $contexts -notcontains $_ })
-    $hasAnyOld  = $toRemove.Count -gt 0
-    $hasAllNew  = $toAdd.Count -eq 0
-
-    if ($hasAnyOld) {
-        $contexts = @($contexts | Where-Object { $toRemove -notcontains $_ }) + $toAdd
+    # Force the set to be exactly $DesiredChecks: add what's missing, drop
+    # anything not listed.
+    $contexts = @($rsc.contexts)
+    $desired  = @($DesiredChecks)
+    $missing  = @($desired  | Where-Object { $contexts -notcontains $_ })
+    $extra    = @($contexts | Where-Object { $desired  -notcontains $_ })
+    if ($missing.Count -eq 0 -and $extra.Count -eq 0) {
+        return [pscustomobject]@{ Status = 'SKIP'; Reason = 'already up to date' }
     }
-    elseif ($AddIfMissing -and -not $hasAllNew) {
-        $contexts = @($contexts) + $toAdd
-    }
-    else {
-        $reason = if ($hasAllNew) { 'already up to date' } else { 'no old checks present (use -AddIfMissing to add anyway)' }
-        return [pscustomobject]@{ Status = 'SKIP'; Reason = $reason }
-    }
+    $contexts = $desired
 
     # GET returns nested { enabled: bool } objects; PUT expects flat booleans.
     $payload = [ordered]@{
@@ -281,7 +265,7 @@ try {
         foreach ($branch in $Branches) {
             $r = Update-BranchProtection `
                 -RepoFull $repo -Branch $branch `
-                -OldChecks $OldChecks -NewChecks $NewChecks `
+                -DesiredChecks $DesiredChecks `
                 -AddIfMissing:$AddIfMissing
             $line = [pscustomobject]@{
                 Repo   = $repo

--- a/scripts/Update-ModuleBranchProtection.ps1
+++ b/scripts/Update-ModuleBranchProtection.ps1
@@ -19,10 +19,25 @@
     applied by the create-module-repository workflow. Branches that don't
     exist are still skipped.
 
+    Add-only (no removal): to just add one or more checks without removing
+    anything, pass an empty -OldChecks, list only the new check(s) in
+    -NewChecks, and use -AddIfMissing. Existing contexts are read and
+    preserved automatically, so -NewChecks need not repeat them. Because no
+    old check is present to trigger the swap path, -AddIfMissing is required
+    for the addition to apply (note it will also create protection from
+    scratch on unprotected branches).
+
 .EXAMPLE
     pwsh ./Update-ModuleBranchProtection.ps1 -WhatIf
     pwsh ./Update-ModuleBranchProtection.ps1
     pwsh ./Update-ModuleBranchProtection.ps1 -Repos vc-module-news,vc-module-cart
+
+.EXAMPLE
+    # Add a single check without removing any existing ones.
+    pwsh ./Update-ModuleBranchProtection.ps1 `
+        -OldChecks @() `
+        -NewChecks 'swagger-validation' `
+        -AddIfMissing -WhatIf
 #>
 [CmdletBinding(SupportsShouldProcess = $true)]
 param(
@@ -121,6 +136,17 @@ function Invoke-PutProtection {
         [System.IO.File]::WriteAllText($tmp.FullName, $json, [System.Text.UTF8Encoding]::new($false))
         $out = gh api --method PUT "/repos/$RepoFull/branches/$Branch/protection" --input $tmp.FullName 2>&1
         if ($LASTEXITCODE -ne 0) {
+            # Renamed repos answer unsafe methods with 301/307 pointing at the
+            # canonical resource by id (repositories/<id>/...). gh auto-follows
+            # redirects for GET but not for PUT, so on that one case resolve the
+            # current name and retry once. Other failures pass straight through.
+            $canonical = Resolve-RenamedRepo -Output "$out"
+            if ($canonical -and $canonical -ne $RepoFull) {
+                $out = gh api --method PUT "/repos/$canonical/branches/$Branch/protection" --input $tmp.FullName 2>&1
+                if ($LASTEXITCODE -eq 0) {
+                    return [pscustomobject]@{ Status = 'OK'; Reason = "$Action (repo renamed -> $canonical)" }
+                }
+            }
             return [pscustomobject]@{ Status = 'ERROR'; Reason = "$out" }
         }
     }
@@ -128,6 +154,18 @@ function Invoke-PutProtection {
         Remove-Item $tmp.FullName -ErrorAction SilentlyContinue
     }
     return [pscustomobject]@{ Status = 'OK'; Reason = $Action }
+}
+
+# When a write fails with a rename redirect (301/307 carrying a
+# repositories/<id>/... URL), resolve the repo's current full_name from that id.
+# Returns $null when the output isn't such a redirect or the id won't resolve.
+function Resolve-RenamedRepo {
+    param([string]$Output)
+    if ("$Output" -notmatch '\b30[17]\b' -or "$Output" -notmatch 'repositories/(\d+)') { return $null }
+    $repoId = $Matches[1]
+    $full = gh api "repositories/$repoId" --jq '.full_name' 2>&1
+    if ($LASTEXITCODE -ne 0) { return $null }
+    return "$full".Trim()
 }
 
 function Update-BranchProtection {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Bulk branch-protection changes can block merges on module repos if checks are misnamed or not yet reporting; deploy matrix fixes only affect workflow rollout targets.
> 
> **Overview**
> **Branch protection** for new module repos now requires **`swagger-validation`** alongside the existing CI checks. The **`Update-ModuleBranchProtection.ps1`** script is reworked to **converge** each protected branch to an exact **`-DesiredChecks`** list (default matches the create-repo workflow), **removing** any status checks not in that set instead of only swapping old/new pairs. It also **retries** protection updates when GitHub returns a rename redirect (301/307) by resolving the repo’s current name.
> 
> **`deploy-module-workflows.yml`** matrix entries are corrected for renamed modules: **`vc-module-catalog-csv-import`** → **`vc-module-catalog-csv-export-import`**, **`vc-module-u-c-p`** → **`vc-module-ucp`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 823b52bd2aaaf68d8dd4f61614dcc7b393fe9d1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->