### PR TITLE
VCST-5305: Skip module build on version-bump commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
-# v3.800.39
-# https://virtocommerce.atlassian.net/browse/VCST-5246
+# v3.800.40
+# https://virtocommerce.atlassian.net/browse/VCST-5305
 name: VC build
 
 on:

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -1,5 +1,5 @@
-# v3.800.39
-# https://virtocommerce.atlassian.net/browse/VCST-5246
+# v3.800.40
+# https://virtocommerce.atlassian.net/browse/VCST-5305
 name: VC cloud deployment
 
 on:

--- a/.github/workflows/deploy-module-workflows.yml
+++ b/.github/workflows/deploy-module-workflows.yml
@@ -7,7 +7,7 @@ on:
         description: 'Version to deploy'
         required: true
         type: string
-        default: 'v3.800.39'
+        default: 'v3.800.40'
 
 # Least privilege: pushes use the REPO_TOKEN PAT, so GITHUB_TOKEN needs only read.
 permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.39
-# https://virtocommerce.atlassian.net/browse/VCST-5246
+# v3.800.40
+# https://virtocommerce.atlassian.net/browse/VCST-5305
 name: VC deployment
 
 on:

--- a/.github/workflows/docker-image-vulnerability-process.yml
+++ b/.github/workflows/docker-image-vulnerability-process.yml
@@ -1,5 +1,5 @@
-# v3.800.39
-# https://virtocommerce.atlassian.net/browse/VCST-5246
+# v3.800.40
+# https://virtocommerce.atlassian.net/browse/VCST-5305
 name: Docker image vulnerability process
 
 on:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,5 +1,5 @@
-# v3.800.39
-# https://virtocommerce.atlassian.net/browse/VCST-5246
+# v3.800.40
+# https://virtocommerce.atlassian.net/browse/VCST-5305
 name: VC Publish docker
 
 on:

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -1,5 +1,5 @@
-# v3.800.39
-# https://virtocommerce.atlassian.net/browse/VCST-5246
+# v3.800.40
+# https://virtocommerce.atlassian.net/browse/VCST-5305
 name: VC Publish Github release and Nuget package
 
 on:

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -1,5 +1,5 @@
-# v3.800.39
-# https://virtocommerce.atlassian.net/browse/VCST-5246
+# v3.800.40
+# https://virtocommerce.atlassian.net/browse/VCST-5305
 name: Auto tests
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-# v3.800.39
-# https://virtocommerce.atlassian.net/browse/VCST-5246
+# v3.800.40
+# https://virtocommerce.atlassian.net/browse/VCST-5305
 name: Release workflow
 
 on:

--- a/.github/workflows/test-and-sonar.yml
+++ b/.github/workflows/test-and-sonar.yml
@@ -1,5 +1,5 @@
-# v3.800.39
-# https://virtocommerce.atlassian.net/browse/VCST-5246
+# v3.800.40
+# https://virtocommerce.atlassian.net/browse/VCST-5305
 name: VC unit test and sonar scan
 
 on:

--- a/deprecated/workflows/e2e-autotests.yml
+++ b/deprecated/workflows/e2e-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.39
-# https://virtocommerce.atlassian.net/browse/VCST-5246
+# v3.800.40
+# https://virtocommerce.atlassian.net/browse/VCST-5305
 name: Common E2E tests
 
 on:

--- a/deprecated/workflows/e2e.yml
+++ b/deprecated/workflows/e2e.yml
@@ -1,5 +1,5 @@
-# v3.800.39
-# https://virtocommerce.atlassian.net/browse/VCST-5246
+# v3.800.40
+# https://virtocommerce.atlassian.net/browse/VCST-5305
 name: Common katalon tests
 
 on:

--- a/deprecated/workflows/get-metadata.yml
+++ b/deprecated/workflows/get-metadata.yml
@@ -1,5 +1,5 @@
-# v3.800.39
-# https://virtocommerce.atlassian.net/browse/VCST-5246
+# v3.800.40
+# https://virtocommerce.atlassian.net/browse/VCST-5305
 name: Get metadata
 
 on:

--- a/deprecated/workflows/increment-version.yml
+++ b/deprecated/workflows/increment-version.yml
@@ -1,5 +1,5 @@
-# v3.800.39
-# https://virtocommerce.atlassian.net/browse/VCST-5246
+# v3.800.40
+# https://virtocommerce.atlassian.net/browse/VCST-5305
 name: Increment version
 
 on:

--- a/deprecated/workflows/ui-autotests.yml
+++ b/deprecated/workflows/ui-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.39
-# https://virtocommerce.atlassian.net/browse/VCST-5246
+# v3.800.40
+# https://virtocommerce.atlassian.net/browse/VCST-5305
 name: Common UI tests
 
 on:

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -61,10 +61,12 @@ jobs:
           echo "Files changed:"; git diff --name-only "$BEFORE" "$AFTER"
 
           # version-only when every changed +/- line is a "<VersionPrefix|version>X.Y.Z</...>" bump.
+          # || true: a content-less diff (rename/mode-only) makes grep match nothing (exit 1), which
+          # pipefail+set -e would turn into a step failure; fall through and let CI decide instead.
           CHANGED=$(git diff --unified=0 "$BEFORE" "$AFTER" | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
-            | sed -E 's/^[+-][[:space:]]*//; s/[[:space:]]*$//')
+            | sed -E 's/^[+-][[:space:]]*//; s/[[:space:]]*$//' || true)
           NON_VERSION=$(echo "$CHANGED" \
-            | grep -vxE '<(VersionPrefix|version)>[0-9]+\.[0-9]+\.[0-9]+</(VersionPrefix|version)>' \
+            | grep -vxE '<VersionPrefix>[0-9]+\.[0-9]+\.[0-9]+</VersionPrefix>|<version>[0-9]+\.[0-9]+\.[0-9]+</version>' \
             | grep -v '^$' || true)
 
           if [ -n "$CHANGED" ] && [ -z "$NON_VERSION" ]; then

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -1,5 +1,5 @@
-# v3.800.39
-# https://virtocommerce.atlassian.net/browse/VCST-5246
+# v3.800.40
+# https://virtocommerce.atlassian.net/browse/VCST-5305
 name: Module CI
 
 on:
@@ -33,10 +33,54 @@ permissions:
   contents: read
 
 jobs:
+  # Skips build/deploy for version-only bumps (every changed line is a <VersionPrefix>/<version>). Push-only.
+  detect-version-bump:
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      version-only: ${{ steps.detect.outputs.version-only }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect version-bump-only push
+        id: detect
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+        run: |
+          # New branch (no "before" ref) -> run CI.
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            echo "version-only=false" >> "$GITHUB_OUTPUT"; echo "New branch push - running CI."; exit 0
+          fi
+
+          echo "Files changed:"; git diff --name-only "$BEFORE" "$AFTER"
+
+          # version-only when every changed +/- line is a "<VersionPrefix|version>X.Y.Z</...>" bump.
+          CHANGED=$(git diff --unified=0 "$BEFORE" "$AFTER" | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
+            | sed -E 's/^[+-][[:space:]]*//; s/[[:space:]]*$//')
+          NON_VERSION=$(echo "$CHANGED" \
+            | grep -vxE '<(VersionPrefix|version)>[0-9]+\.[0-9]+\.[0-9]+</(VersionPrefix|version)>' \
+            | grep -v '^$' || true)
+
+          if [ -n "$CHANGED" ] && [ -z "$NON_VERSION" ]; then
+            echo "version-only=true"  >> "$GITHUB_OUTPUT"; echo "::notice::Version-only push - skipping CI build."
+          else
+            echo "version-only=false" >> "$GITHUB_OUTPUT"; echo "Non-version changes detected - running CI."
+          fi
+
   ci:
-    if: ${{ github.actor != 'dependabot[bot]' &&
+    needs: detect-version-bump
+    # !cancelled() keeps CI running when detect-version-bump is skipped (PR) or fails (fail-open).
+    if: ${{ !cancelled()
+        && needs.detect-version-bump.outputs.version-only != 'true'
+        && github.actor != 'dependabot[bot]' &&
         (github.event.pull_request.head.repo.full_name == github.repository ||
-        github.event.pull_request.head.repo.full_name == '') }}  # Check that PR not from forked repo and not from Dependabot
+        github.event.pull_request.head.repo.full_name == '') }}  # Skip version-only bumps; PR not from a fork or Dependabot
     runs-on: ubuntu-24.04
     # Default GITHUB_TOKEN creates the release + updates the PR; rest uses the REPO_TOKEN PAT.
     permissions:
@@ -260,10 +304,7 @@ jobs:
         with:
           githubToken: ${{ secrets.REPO_TOKEN }}
 
-      # NOTE: This step is intentionally NOT gated on swagger-validation. In the normal flow swagger
-      # runs (and must pass) on the PR into dev before code is merged, so anything reaching dev/master/main
-      # is already validated. The only uncovered case is a direct push that bypasses the PR; that is closed
-      # by the branch protection rule on dev (required swagger check + no direct pushes), not in-workflow.
+      # Not gated on swagger-validation: PRs into dev already validate it, and direct pushes are blocked by branch protection.
       - name: Publish Manifest
         if: ${{ (github.ref == 'refs/heads/dev' && github.event_name != 'workflow_dispatch') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
         uses: VirtoCommerce/vc-github-actions/publish-manifest@master
@@ -310,7 +351,7 @@ jobs:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.39
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.40
     with:
       installModules: 'false'
       installCustomModule: 'true'
@@ -353,9 +394,7 @@ jobs:
           platformImage: ghcr.io/virtocommerce/platform
 
   deploy-cloud:
-    # always() + explicit result checks: swagger-validation only runs on the dev flow, so it is
-    # 'skipped' on master/main pushes. Deploy when swagger passed (dev) or was skipped (master/main),
-    # but block when it failed (e.g. a direct push to dev that bypassed branch protection).
+    # always() + explicit checks: deploy when swagger-validation passed (dev) or was skipped (master/main); block on failure.
     if: ${{ always()
       && needs.ci.result == 'success'
       && (needs.swagger-validation.result == 'success' || needs.swagger-validation.result == 'skipped')
@@ -367,7 +406,7 @@ jobs:
     permissions:
       contents: read
       deployments: write
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.39
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.40
     with:
       releaseSource: module
       moduleId: ${{ needs.ci.outputs.moduleId }}
@@ -375,4 +414,4 @@ jobs:
       moduleBlob: ${{ needs.ci.outputs.blobId }}
       jiraKeys: ${{ needs.ci.outputs.jira-keys }}
       matrix: '{"include":${{ needs.ci.outputs.matrix }}}'
-    secrets: inherit # zizmor: ignore[secrets-inherit] deploy-cloud.yml@v3.800.39 reads undeclared org secrets; explicit passing needs a new release + tag bump
+    secrets: inherit # zizmor: ignore[secrets-inherit] deploy-cloud.yml@v3.800.40 reads undeclared org secrets; explicit passing needs a new release + tag bump

--- a/workflow-templates/module-deploy.yml
+++ b/workflow-templates/module-deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.39
-# https://virtocommerce.atlassian.net/browse/VCST-5246
+# v3.800.40
+# https://virtocommerce.atlassian.net/browse/VCST-5305
 name: Module deployment
 on:
   workflow_dispatch:

--- a/workflow-templates/module-release-hotfix.yml
+++ b/workflow-templates/module-release-hotfix.yml
@@ -1,5 +1,5 @@
-# v3.800.39
-# https://virtocommerce.atlassian.net/browse/VCST-5246
+# v3.800.40
+# https://virtocommerce.atlassian.net/browse/VCST-5305
 name: Release hotfix
 
 on:
@@ -17,12 +17,12 @@ permissions:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.39
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.40
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.39    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.40    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -55,7 +55,7 @@ jobs:
       pull-requests: write
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.39
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.40
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/workflow-templates/publish-nugets.yml
+++ b/workflow-templates/publish-nugets.yml
@@ -1,5 +1,5 @@
-# v3.800.39
-# https://virtocommerce.atlassian.net/browse/VCST-5246
+# v3.800.40
+# https://virtocommerce.atlassian.net/browse/VCST-5305
 name: Publish nuget
 
 on:
@@ -17,12 +17,12 @@ permissions:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.39    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.40    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.39    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.40    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -37,7 +37,7 @@ jobs:
       pull-requests: write
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.39
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.40
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -1,5 +1,5 @@
-# v3.800.39
-# https://virtocommerce.atlassian.net/browse/VCST-5246
+# v3.800.40
+# https://virtocommerce.atlassian.net/browse/VCST-5305
 name: Release
 
 on:
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.39    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.40    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
##What
Adds a detect-version-bump job to module-ci.yml that skips the CI build/deploy when a push changes only <VersionPrefix>/<version> lines (the automated version-bump commits). Also bumps the workflow version v3.800.39 → v3.800.40 across all templates and condenses two explanatory comments.

##Why
Automated version-bump commits pushed back to dev/master/main re-triggered a full module rebuild and deploy for no functional change. This avoids the wasted CI/CD run.

##How it's safe
Push-only: the detector runs on push; PRs are unaffected.
Fail-open: ci uses !cancelled() && version-only != 'true', so it still runs if the detector is skipped (PRs) or errors.
Conservative classifier: anything it can't prove is version-only (attributes, <Version>, multi-part/suffix versions, mixed changes) falls through to a full build. Skip cascades cleanly to pytest/swagger-validation/deploy-cloud.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when module builds, tests, and cloud deploy run on protected branches; misclassification could skip needed CI or still run full pipelines, but fail-open and conservative diff rules limit skip scope.
> 
> **Overview**
> **Module CI** gains a push-only `detect-version-bump` job that diffs `github.event.before` → `github.sha` and sets `version-only=true` when every changed line is only `<VersionPrefix>X.Y.Z</VersionPrefix>` or `<version>X.Y.Z</version>`. The main `ci` job now `needs` that detector and is skipped when `version-only` is true; it still runs on PRs (detector skipped), new-branch pushes, detector failure (`!cancelled()` fail-open), and any push the classifier cannot prove is version-only.
> 
> **Release alignment:** shared workflow bundle **v3.800.39 → v3.800.40** (VCST-5305) across `.github/workflows`, `workflow-templates`, `deprecated/workflows`, and `deploy-module-workflows` default; reusable workflow `@` refs in templates updated to match. A couple of inline comments in `module-ci.yml` were shortened; some YAML step lines had whitespace-only normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d0aefef93e89b060cb01c0acad43a5d3845830f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->