### PR TITLE
VCST-5305: Fix auto-tests/swagger-validation skipped on PR

### DIFF
--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -350,8 +350,10 @@ jobs:
           STEPS_PUSH_BUILD_INFO_TO_JIRA_OUTPUTS_RESPONSE: ${{ steps.push_build_info_to_jira.outputs.response }}
 
   auto-tests:
-    if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
-        (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
+    # !cancelled() keeps this running when detect-version-bump is skipped (PR); ci.result == 'success' still gates on the build.
+    if: ${{ !cancelled() && needs.ci.result == 'success' && (
+        ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
+        (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request'))) }}
     needs: ci
     uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.40
     with:
@@ -370,8 +372,10 @@ jobs:
       sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
 
   swagger-validation:
-    if: ${{ github.ref == 'refs/heads/dev' ||
-        (github.event_name == 'pull_request' && github.base_ref == 'dev') }}
+    # !cancelled() keeps this running when detect-version-bump is skipped (PR); ci.result == 'success' still gates on the build.
+    if: ${{ !cancelled() && needs.ci.result == 'success' && (
+        github.ref == 'refs/heads/dev' ||
+        (github.event_name == 'pull_request' && github.base_ref == 'dev')) }}
     needs: ci
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
## Problem

The `detect-version-bump` job added in v3.800.40 is push-only (`if: github.event_name == 'push'`), so it is **skipped** on `pull_request`. GitHub propagates a skip through a job's transitive `needs` closure unless the job opts out with `always()`/`!cancelled()`.

`ci` already carries `!cancelled()` (with a comment explaining it), but `auto-tests` and `swagger-validation` did not — so both were **skipped on PRs into `dev`**, while `ci` still succeeded and Module CI reported ✅. Result: PRs looked green but integration tests + swagger validation never ran.

### Evidence
- Before 06.07 (no `detect-version-bump`): auto-tests ran on PRs — e.g. `vc-module-x-order` run `28599768363` (02.07, `pull_request`).
- After 06.07, same PRs / same event / `base=dev`, `ci: success` but `auto-tests: skipped` — e.g. `vc-module-x-order` `28778099361`, `vc-module-x-cart` `28777163697`, `vc-module-cart` `28775854914`, `vc-module-order` `28776698640`.
- The `if` blocks of `auto-tests`/`swagger-validation` themselves were unchanged — the `needs` graph broke.

## Fix

Add `!cancelled() && needs.ci.result == 'success'` to `auto-tests` and `swagger-validation`, mirroring `ci`. Original trigger expressions preserved verbatim inside parentheses; `needs.ci.result == 'success'` keeps integration gated on a passing build (and correctly blocks it when the build fails, which `!cancelled()` alone would not).

## Rollout

No version bump / no re-release — `# v3.800.40` header and `@v3.800.40` refs are unchanged. After merge, sync the corrected template into modules by running **Deploy Module workflows** with `version = main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow `if` condition changes only; restores intended PR CI behavior with no application or security logic changes.
> 
> **Overview**
> **Restores integration tests and swagger validation on PRs into `dev`** after push-only `detect-version-bump` was introduced in v3.800.40. When that job is skipped on `pull_request`, GitHub can skip transitive dependents unless they opt out—`ci` already used `!cancelled()`, but **`auto-tests`** and **`swagger-validation`** did not, so PRs could show green while pytest and swagger never ran.
> 
> Both jobs now gate on **`!cancelled() && needs.ci.result == 'success'`** in addition to their existing branch/event triggers, matching **`ci`** and still blocking tests when the build fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aab11e29d8faabbe7f04ae52bf9d88b00ff598f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->