### PR TITLE
VCST-5373: Use NuGet trusted publishing instead of long-living API key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.42
+# https://virtocommerce.atlassian.net/browse/VCST-5373
 name: VC build
 
 on:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
     steps: 
 
     - name: Set up Node 24
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '24'
 

--- a/.github/workflows/create-module-repository.yml
+++ b/.github/workflows/create-module-repository.yml
@@ -628,6 +628,29 @@ jobs:
             fi
           fi
 
+      - name: NuGet Trusted Publishing instructions
+        # nuget.org has no API for Trusted Publishing policies and requires a
+        # federated (MFA) login, so the 3 policies for this repo can't be created
+        # from CI. Surface the exact manual command for an operator to run locally.
+        # See .github/scripts/nuget-trusted-publishers/README.md.
+        run: |
+          {
+            echo "### ⚠️ Manual step: NuGet Trusted Publishing"
+            echo ""
+            echo "nuget.org has no API for Trusted Publishing policies (federated MFA login only),"
+            echo "so the 3 publishing policies for **\`$REPO_NAME\`** must be created manually."
+            echo ""
+            echo "Log in to nuget.org in your browser, then from a checkout of the \`.github\` repo run"
+            echo "(you'll be prompted to paste your nuget.org \`cookie:\` header — see the README):"
+            echo ""
+            echo '```bash'
+            echo "cd .github/scripts/nuget-trusted-publishers"
+            echo "node add-nuget-trusted-publishers.mjs --repos $REPO_NAME"
+            echo '```'
+            echo ""
+            echo "This creates policies for \`module-ci.yml\`, \`publish-nugets.yml\` and \`module-release-hotfix.yml\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Delete GitHub repository (rollback)
         if: failure() && steps.create-repo.outputs.created == 'true'
         run: |

--- a/.github/workflows/create-module-repository.yml
+++ b/.github/workflows/create-module-repository.yml
@@ -632,7 +632,7 @@ jobs:
         # nuget.org has no API for Trusted Publishing policies and requires a
         # federated (MFA) login, so the 3 policies for this repo can't be created
         # from CI. Surface the exact manual command for an operator to run locally.
-        # See .github/scripts/nuget-trusted-publishers/README.md.
+        # See scripts/nuget-trusted-publishers/README.md.
         run: |
           {
             echo "### ⚠️ Manual step: NuGet Trusted Publishing"
@@ -644,7 +644,7 @@ jobs:
             echo "(you'll be prompted to paste your nuget.org \`cookie:\` header — see the README):"
             echo ""
             echo '```bash'
-            echo "cd .github/scripts/nuget-trusted-publishers"
+            echo "cd scripts/nuget-trusted-publishers"
             echo "node add-nuget-trusted-publishers.mjs --repos $REPO_NAME"
             echo '```'
             echo ""

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.42
+# https://virtocommerce.atlassian.net/browse/VCST-5373
 name: VC cloud deployment
 
 on:

--- a/.github/workflows/deploy-module-workflows.yml
+++ b/.github/workflows/deploy-module-workflows.yml
@@ -7,7 +7,7 @@ on:
         description: 'Version to deploy'
         required: true
         type: string
-        default: 'v3.800.40'
+        default: 'v3.800.42'
 
 # Least privilege: pushes use the REPO_TOKEN PAT, so GITHUB_TOKEN needs only read.
 permissions:

--- a/.github/workflows/deploy-module-workflows.yml
+++ b/.github/workflows/deploy-module-workflows.yml
@@ -90,11 +90,13 @@ jobs:
                   ,vc-module-quote
                   ,vc-module-return
                   ,vc-module-sales-rep
+                  ,vc-module-sanity
                   ,vc-module-search
                   ,vc-module-seo
                   ,vc-module-seq-log
                   ,vc-module-shipping
                   ,vc-module-shipstation
+                  ,vc-module-shopify-taxonomy
                   ,vc-module-sitemaps
                   ,vc-module-skyflow
                   ,vc-module-sql-queries

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.42
+# https://virtocommerce.atlassian.net/browse/VCST-5373
 name: VC deployment
 
 on:

--- a/.github/workflows/docker-image-vulnerability-process.yml
+++ b/.github/workflows/docker-image-vulnerability-process.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.42
+# https://virtocommerce.atlassian.net/browse/VCST-5373
 name: Docker image vulnerability process
 
 on:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.42
+# https://virtocommerce.atlassian.net/browse/VCST-5373
 name: VC Publish docker
 
 on:

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.42
+# https://virtocommerce.atlassian.net/browse/VCST-5373
 name: VC Publish Github release and Nuget package
 
 on:

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -100,6 +100,11 @@ jobs:
         makeLatest: ${{ inputs.makeLatest }}
       uses: VirtoCommerce/vc-github-actions/publish-github-release@master
 
+    # Pushes with the caller-supplied `nugetKey`. Do NOT add NuGet/login (OIDC) here to mint the
+    # key: this is a cross-repo reusable, so the OIDC token's job_workflow_ref would be this file
+    # (in the .github repo), not the caller's workflow, and no per-repo trust policy would match
+    # it (NuGet/login issues #6 and #9). Callers using Trusted Publishing mint the short-lived key
+    # in their OWN job and pass it in via the `nugetKey` secret.
     - name: Publish Nuget
       if: ${{ inputs.forceNuget }}
       uses: VirtoCommerce/vc-github-actions/publish-nuget@master

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.42
+# https://virtocommerce.atlassian.net/browse/VCST-5373
 name: Auto tests
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.42
+# https://virtocommerce.atlassian.net/browse/VCST-5373
 name: Release workflow
 
 on:

--- a/.github/workflows/test-and-sonar.yml
+++ b/.github/workflows/test-and-sonar.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.42
+# https://virtocommerce.atlassian.net/browse/VCST-5373
 name: VC unit test and sonar scan
 
 on:

--- a/.github/workflows/test-and-sonar.yml
+++ b/.github/workflows/test-and-sonar.yml
@@ -18,7 +18,7 @@ jobs:
     steps: 
 
     - name: Set up Node 24
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '24'
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vs
+node_modules/

--- a/deprecated/workflows/e2e-autotests.yml
+++ b/deprecated/workflows/e2e-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.42
+# https://virtocommerce.atlassian.net/browse/VCST-5373
 name: Common E2E tests
 
 on:

--- a/deprecated/workflows/e2e.yml
+++ b/deprecated/workflows/e2e.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.42
+# https://virtocommerce.atlassian.net/browse/VCST-5373
 name: Common katalon tests
 
 on:

--- a/deprecated/workflows/get-metadata.yml
+++ b/deprecated/workflows/get-metadata.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.42
+# https://virtocommerce.atlassian.net/browse/VCST-5373
 name: Get metadata
 
 on:

--- a/deprecated/workflows/increment-version.yml
+++ b/deprecated/workflows/increment-version.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.42
+# https://virtocommerce.atlassian.net/browse/VCST-5373
 name: Increment version
 
 on:

--- a/deprecated/workflows/ui-autotests.yml
+++ b/deprecated/workflows/ui-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.42
+# https://virtocommerce.atlassian.net/browse/VCST-5373
 name: Common UI tests
 
 on:

--- a/scripts/nuget-trusted-publishers/README.md
+++ b/scripts/nuget-trusted-publishers/README.md
@@ -1,0 +1,77 @@
+# NuGet.org Trusted Publishing policies
+
+Creates [Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing)
+policies on nuget.org for VirtoCommerce **module** repositories, so their GitHub
+Actions workflows can push packages with short-lived OIDC keys instead of a
+long-lived `NUGET_KEY`.
+
+Each module repo gets **3 policies** (one per publishing workflow, Environment left blank):
+
+| Workflow file               | Policy name pattern            |
+| --------------------------- | ------------------------------ |
+| `module-ci.yml`             | `<repo>-module-ci`             |
+| `publish-nugets.yml`        | `<repo>-publish-nugets`        |
+| `module-release-hotfix.yml` | `<repo>-module-release-hotfix` |
+
+## Why it asks for a cookie
+
+nuget.org has **no public API** for managing Trusted Publishing policies — they can
+only be created on the website, via an anti-forgery-protected endpoint that requires
+an authenticated **session cookie**. Login is federated Microsoft-account auth
+(MFA + corporate SSO), so there's no password or API key a script can use, and
+automating the login in a clean browser fails because the corporate SSO extension
+isn't present. The workaround: you log in in your **normal** browser (where SSO
+works) and hand the script the session cookie.
+
+Nothing is stored — the cookie is read at runtime, kept in memory for the run only,
+and never written to disk. There is no browser and no dependency to install
+(pure Node 18+, built-in `fetch`).
+
+## Get the cookie (once per run)
+
+1. Log in at <https://www.nuget.org> and open your account → **Trusted Publishing**.
+2. Open DevTools (F12) → **Network** tab → click any `www.nuget.org` request.
+3. Under **Request Headers**, copy the whole value of the `cookie:` header.
+
+> Alternatively, right-click the request → **Copy → Copy as cURL**, save it to a
+> file, and pass `--curl <file>` — the script extracts the cookie from it.
+
+## Usage
+
+```bash
+cd .github/scripts/nuget-trusted-publishers
+
+# After creating a new module repo (you'll be prompted to paste the cookie):
+node add-nuget-trusted-publishers.mjs --repos vc-module-cart
+
+# Several at once:
+node add-nuget-trusted-publishers.mjs --repos vc-module-cart,vc-module-news
+
+# Preview only, no changes:
+node add-nuget-trusted-publishers.mjs --repos vc-module-cart --dry-run
+
+# Read the cookie from a saved "Copy as cURL" file instead of pasting:
+node add-nuget-trusted-publishers.mjs --repos vc-module-cart --curl ./req.txt
+```
+
+The script is **idempotent**: existing identical policies are detected and skipped,
+so re-running is safe. If the cookie has expired it will tell you to grab a fresh one.
+
+### Options
+
+| Option            | Default        | Description                                          |
+| ----------------- | -------------- | ---------------------------------------------------- |
+| `--repos a,b,c`   | *(required)*   | Repo names (with or without `owner/` prefix).        |
+| `--owner`         | `VirtoCommerce`| nuget.org package owner that will own the policies.  |
+| `--github-owner`  | `VirtoCommerce`| GitHub org used as the policy's `RepositoryOwner`.   |
+| `--workflows a,b` | the 3 above    | Override the workflow file list.                     |
+| `--curl <file>`   | *(prompt)*     | Read the cookie from a saved "Copy as cURL" file.    |
+| `--dry-run`       | off            | Show what would be created; do not POST.             |
+
+## New-repo checklist
+
+After creating a `vc-module-*` repo, run:
+
+```bash
+node add-nuget-trusted-publishers.mjs --repos <new-repo-name>
+```

--- a/scripts/nuget-trusted-publishers/README.md
+++ b/scripts/nuget-trusted-publishers/README.md
@@ -39,7 +39,7 @@ and never written to disk. There is no browser and no dependency to install
 ## Usage
 
 ```bash
-cd .github/scripts/nuget-trusted-publishers
+cd scripts/nuget-trusted-publishers
 
 # After creating a new module repo (you'll be prompted to paste the cookie):
 node add-nuget-trusted-publishers.mjs --repos vc-module-cart

--- a/scripts/nuget-trusted-publishers/add-nuget-trusted-publishers.mjs
+++ b/scripts/nuget-trusted-publishers/add-nuget-trusted-publishers.mjs
@@ -1,0 +1,407 @@
+/**
+ * Create NuGet.org Trusted Publishing policies for module repositories.
+ *
+ * WHY THIS ASKS FOR A COOKIE (and not a username/password):
+ *   NuGet.org has NO public API for managing Trusted Publishing policies. They can
+ *   only be created through the website, via the anti-forgery-protected MVC endpoint
+ *   POST /account/GenerateTrustedPublisherPolicy (see NuGetGallery UsersController),
+ *   which requires an authenticated *session cookie*. NuGet.org login is federated
+ *   Microsoft-account auth (MFA + corporate SSO), so there is no password/API-key you
+ *   can hand a script. The one credential the site accepts is the session cookie your
+ *   browser already holds after you log in.
+ *
+ * HOW IT WORKS (no browser, nothing stored):
+ *   1. You log in to nuget.org in your NORMAL browser (where your SSO plugin works).
+ *   2. You paste that session's Cookie header when this script prompts for it.
+ *   3. The script GETs /account/trustedpublishing to grab a matching anti-forgery
+ *      token, then POSTs the 3 policies for each repo. The cookie lives only in
+ *      memory for the run and is never written to disk.
+ *
+ * Each module repo gets 3 policies (Environment left blank), one per workflow:
+ *   module-ci.yml, publish-nugets.yml, module-release-hotfix.yml
+ *
+ * GETTING THE COOKIE (once per run):
+ *   - Log in at https://www.nuget.org and open your account -> Trusted Publishing.
+ *   - Open DevTools (F12) -> Network tab -> click any www.nuget.org request.
+ *   - Under Request Headers, copy the whole value of the `cookie:` header.
+ *     (Or right-click the request -> Copy -> Copy as cURL, save to a file, and pass
+ *      it with --curl <file>; the script extracts the cookie from it.)
+ *
+ * USAGE:
+ *   node add-nuget-trusted-publishers.mjs --repos vc-module-cart
+ *   node add-nuget-trusted-publishers.mjs --repos vc-module-cart,vc-module-news
+ *   node add-nuget-trusted-publishers.mjs --repos vc-module-cart --dry-run
+ *   node add-nuget-trusted-publishers.mjs --repos vc-module-cart --curl ./req.txt
+ *
+ * OPTIONS:
+ *   --repos a,b,c     Explicit repo names (with or without the owner/ prefix). Required.
+ *   --owner <name>    NuGet.org package owner that will own the policies.  Default: VirtoCommerce
+ *   --github-owner    GitHub org used as the policy's RepositoryOwner.      Default: VirtoCommerce
+ *   --workflows a,b   Override the workflow file list (comma-separated).
+ *   --curl <file>     Read the cookie from a saved "Copy as cURL" file instead of prompting.
+ *   --dry-run         Show what would be created; do not POST.
+ *   --help            Show this help.
+ *
+ * Requires Node 18+ (uses built-in fetch). No npm install needed.
+ */
+
+import readline from 'node:readline';
+import { readFileSync } from 'node:fs';
+
+const NUGET_ORIGIN = 'https://www.nuget.org';
+const TP_URL = `${NUGET_ORIGIN}/account/trustedpublishing`;
+const GITHUB_ACTIONS_PUBLISHER = 'GitHubActions';
+const DEFAULT_WORKFLOWS = ['module-ci.yml', 'publish-nugets.yml', 'module-release-hotfix.yml'];
+const USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36';
+
+// ---------------------------------------------------------------------------
+// Args
+// ---------------------------------------------------------------------------
+function parseArgs(argv) {
+  const args = {
+    repos: [],
+    owner: 'VirtoCommerce',
+    githubOwner: 'VirtoCommerce',
+    workflows: DEFAULT_WORKFLOWS,
+    curl: '',
+    dryRun: false,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    const next = () => argv[++i];
+    switch (a) {
+      case '--repos': args.repos = splitList(next()); break;
+      case '--owner': args.owner = next(); break;
+      case '--github-owner': args.githubOwner = next(); break;
+      case '--workflows': args.workflows = splitList(next()); break;
+      case '--curl': args.curl = next(); break;
+      case '--dry-run': args.dryRun = true; break;
+      case '--help': case '-h': args.help = true; break;
+      default: throw new Error(`Unknown argument: ${a}`);
+    }
+  }
+  return args;
+}
+
+const splitList = (s) => String(s || '').split(',').map((x) => x.trim()).filter(Boolean);
+
+// Repo names may arrive as "owner/name"; the policy criteria wants the bare name.
+const bareRepo = (r) => (r.includes('/') ? r.split('/').pop() : r);
+
+// ---------------------------------------------------------------------------
+// Credentials (session cookie) — prompted per run, kept in memory only
+// ---------------------------------------------------------------------------
+async function readCookie(curlFile) {
+  let raw;
+  if (curlFile) {
+    raw = readFileSync(curlFile, 'utf8');
+  } else if (!process.stdin.isTTY) {
+    raw = await readAllStdin();
+  } else {
+    raw = await prompt(
+      'Log in to nuget.org in your browser, then paste your Cookie header here.\n' +
+        '(DevTools -> Network -> a www.nuget.org request -> Request Headers -> "cookie:" value)\n' +
+        'Cookie: ',
+    );
+  }
+  const cookie = extractCookie(raw);
+  if (!cookie || !cookie.includes('=')) {
+    throw new Error('No cookie found in the input. Paste the full "cookie:" header value.');
+  }
+  return cookie;
+}
+
+function extractCookie(input) {
+  const text = String(input || '').trim();
+  // "Copy as cURL" forms: -H 'cookie: ...'  or  -b '...' / --cookie '...'
+  let m = text.match(/-H\s+\$?['"]cookie:\s*([\s\S]*?)['"]/i);
+  if (m) return m[1].trim();
+  m = text.match(/(?:-b|--cookie)\s+\$?['"]([\s\S]*?)['"]/i);
+  if (m) return m[1].trim();
+  // Raw header, optionally prefixed with "cookie:".
+  m = text.match(/^\s*cookie:\s*([\s\S]+)$/i);
+  if (m) return m[1].trim();
+  return text;
+}
+
+function readAllStdin() {
+  return new Promise((resolve) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (c) => (data += c));
+    process.stdin.on('end', () => resolve(data));
+  });
+}
+
+function prompt(question) {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Cookie jar helpers (we manage the Cookie header ourselves)
+// ---------------------------------------------------------------------------
+function parseCookieHeader(header) {
+  const jar = new Map();
+  for (const part of String(header).split(';')) {
+    const eq = part.indexOf('=');
+    if (eq < 0) continue;
+    const name = part.slice(0, eq).trim();
+    if (name) jar.set(name, part.slice(eq + 1).trim());
+  }
+  return jar;
+}
+
+function applySetCookies(jar, setCookies) {
+  for (const sc of setCookies || []) {
+    const first = sc.split(';')[0];
+    const eq = first.indexOf('=');
+    if (eq < 0) continue;
+    const name = first.slice(0, eq).trim();
+    const value = first.slice(eq + 1).trim();
+    // A deleted cookie (expired/empty) is removed rather than sent back.
+    if (name) {
+      if (value === '' || /expires=Thu, 01 Jan 1970/i.test(sc)) jar.delete(name);
+      else jar.set(name, value);
+    }
+  }
+}
+
+const serializeJar = (jar) => [...jar.entries()].map(([k, v]) => `${k}=${v}`).join('; ');
+
+// ---------------------------------------------------------------------------
+// NuGet page state: anti-forgery token, endpoint URL, owners, existing policies
+// ---------------------------------------------------------------------------
+async function fetchTpState(jar) {
+  const res = await fetch(TP_URL, {
+    headers: { Cookie: serializeJar(jar), 'User-Agent': USER_AGENT, Accept: 'text/html' },
+    redirect: 'follow',
+  });
+  applySetCookies(jar, res.headers.getSetCookie?.());
+  const body = await res.text();
+  const authed = !/logon/i.test(res.url) && /__RequestVerificationToken/.test(body);
+  if (!authed) return { authed: false };
+
+  const token = extractToken(body);
+  if (!token) return { authed: false };
+
+  const initial = extractInitialData(body);
+  const generateUrl = initial?.GenerateUrl
+    ? new URL(initial.GenerateUrl, NUGET_ORIGIN).toString()
+    : `${NUGET_ORIGIN}/account/GenerateTrustedPublisherPolicy`;
+  const owners = (initial?.PackageOwners || []).map((o) => (typeof o === 'string' ? o : o.Owner || o.Username || o.name));
+  const policies = initial?.Policies || [];
+  return { authed: true, token, generateUrl, owners, policies };
+}
+
+function extractToken(html) {
+  const patterns = [
+    /name="__RequestVerificationToken"[^>]*\bvalue="([^"]+)"/i,
+    /\bvalue="([^"]+)"[^>]*name="__RequestVerificationToken"/i,
+  ];
+  for (const re of patterns) {
+    const m = html.match(re);
+    if (m) return decodeEntities(m[1]);
+  }
+  return null;
+}
+
+// The view emits `var initialData = @Html.ToJson(new { ... });` inline. Pull the
+// object out with a brace-depth scan that respects quoted strings.
+function extractInitialData(html) {
+  const at = html.indexOf('initialData');
+  if (at < 0) return null;
+  const braceStart = html.indexOf('{', at);
+  if (braceStart < 0) return null;
+
+  let depth = 0;
+  let inStr = false;
+  let quote = '';
+  let esc = false;
+  for (let i = braceStart; i < html.length; i++) {
+    const ch = html[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (ch === '\\') esc = true;
+      else if (ch === quote) inStr = false;
+      continue;
+    }
+    if (ch === '"' || ch === "'") { inStr = true; quote = ch; continue; }
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        const raw = html.slice(braceStart, i + 1);
+        try { return JSON.parse(raw); }
+        catch { try { return JSON.parse(decodeEntities(raw)); } catch { return null; } }
+      }
+    }
+  }
+  return null;
+}
+
+const decodeEntities = (s) =>
+  String(s)
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+
+function policyExists(policies, { owner, githubOwner, repo, workflow }) {
+  return policies.some((p) => {
+    const d = p.PolicyDetails || p;
+    return (
+      String(p.Owner || '').toLowerCase() === owner.toLowerCase() &&
+      String(d.RepositoryOwner || '').toLowerCase() === githubOwner.toLowerCase() &&
+      String(d.Repository || '').toLowerCase() === repo.toLowerCase() &&
+      String(d.WorkflowFile || '').toLowerCase() === workflow.toLowerCase() &&
+      !String(d.Environment || '')
+    );
+  });
+}
+
+async function createPolicy(jar, { generateUrl, token, policyName, owner, criteria }) {
+  const res = await fetch(generateUrl, {
+    method: 'POST',
+    headers: {
+      Cookie: serializeJar(jar),
+      'User-Agent': USER_AGENT,
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'X-Requested-With': 'XMLHttpRequest',
+      Referer: TP_URL,
+    },
+    body: new URLSearchParams({
+      policyName,
+      owner,
+      criteria: JSON.stringify(criteria),
+      __RequestVerificationToken: token,
+    }),
+    redirect: 'manual',
+  });
+  applySetCookies(jar, res.headers.getSetCookie?.());
+  const status = res.status;
+  const text = await res.text();
+  if (status >= 200 && status < 300) {
+    // The endpoint returns 200 with a JSON error string for validation failures too.
+    if (/"?(error|Message)"?\s*:/i.test(text) && !/policyName|PolicyDetails|Key/i.test(text)) {
+      return { ok: false, reason: snippet(text) };
+    }
+    return { ok: true };
+  }
+  return { ok: false, reason: `HTTP ${status}: ${snippet(text)}` };
+}
+
+const snippet = (t) => String(t).replace(/\s+/g, ' ').trim().slice(0, 300);
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) { printHelp(); return 0; }
+
+  const repos = [...new Set(args.repos.map(bareRepo))].sort();
+  if (repos.length === 0) {
+    throw new Error('No repos specified. Use --repos <a,b,c>.');
+  }
+
+  console.log(`Owner (nuget):   ${args.owner}`);
+  console.log(`RepositoryOwner: ${args.githubOwner}`);
+  console.log(`Workflows:       ${args.workflows.join(', ')}`);
+  console.log(`Repos (${repos.length}):       ${repos.join(', ')}`);
+  if (args.dryRun) console.log('Mode:            DRY RUN (no changes will be made)');
+  console.log('');
+
+  const jar = parseCookieHeader(await readCookie(args.curl));
+  const state = await fetchTpState(jar);
+  if (!state.authed) {
+    throw new Error(
+      'The cookie did not authenticate (expired or incomplete). Log in to nuget.org again ' +
+        'and paste a fresh "cookie:" header.',
+    );
+  }
+
+  if (state.owners.length && !state.owners.some((o) => o.toLowerCase() === args.owner.toLowerCase())) {
+    console.warn(
+      `WARNING: "${args.owner}" is not in your available package owners [${state.owners.join(', ')}]. ` +
+        'The POST will likely be rejected. Pass --owner with a valid owner.',
+    );
+  }
+
+  const results = [];
+  for (const repo of repos) {
+    for (const workflow of args.workflows) {
+      const policyName = `${repo}-${workflow.replace(/\.ya?ml$/i, '')}`;
+      const criteria = {
+        Name: GITHUB_ACTIONS_PUBLISHER,
+        RepositoryOwner: args.githubOwner,
+        Repository: repo,
+        WorkflowFile: workflow,
+        Environment: '',
+      };
+      const label = `${repo} / ${workflow}`;
+
+      if (policyExists(state.policies, { owner: args.owner, githubOwner: args.githubOwner, repo, workflow })) {
+        results.push({ label, status: 'SKIP' });
+        log('SKIP', label, 'already exists');
+        continue;
+      }
+      if (args.dryRun) {
+        results.push({ label, status: 'DRYRUN' });
+        log('DRYRUN', label, `would create "${policyName}"`);
+        continue;
+      }
+
+      const r = await createPolicy(jar, {
+        generateUrl: state.generateUrl,
+        token: state.token,
+        policyName,
+        owner: args.owner,
+        criteria,
+      });
+      if (r.ok) {
+        results.push({ label, status: 'OK' });
+        log('OK', label, `created "${policyName}"`);
+      } else {
+        results.push({ label, status: 'ERROR' });
+        log('ERROR', label, r.reason);
+      }
+    }
+  }
+
+  console.log('\nSummary:');
+  const byStatus = results.reduce((m, r) => ((m[r.status] = (m[r.status] || 0) + 1), m), {});
+  for (const [k, v] of Object.entries(byStatus)) console.log(`  ${k.padEnd(7)} ${v}`);
+
+  return results.some((r) => r.status === 'ERROR') ? 1 : 0;
+}
+
+function log(status, label, reason) {
+  const colors = { OK: 32, SKIP: 90, DRYRUN: 36, ERROR: 31 };
+  const c = colors[status] || 37;
+  console.log(`\x1b[${c}m[${status.padEnd(6)}]\x1b[0m ${label}: ${reason}`);
+}
+
+function printHelp() {
+  console.log(`See the header comment in ${import.meta.url}\n`);
+  console.log('Common usage:');
+  console.log('  node add-nuget-trusted-publishers.mjs --repos vc-module-cart');
+  console.log('  node add-nuget-trusted-publishers.mjs --repos vc-module-cart,vc-module-news');
+  console.log('  node add-nuget-trusted-publishers.mjs --repos vc-module-cart --dry-run');
+  console.log('  node add-nuget-trusted-publishers.mjs --repos vc-module-cart --curl ./req.txt');
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    console.error(`\nFATAL: ${err.message}`);
+    process.exit(1);
+  });

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -205,8 +205,9 @@ jobs:
         id: nuget_login
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         with:
-          # nuget.org user that created the trust policy (shared service account); org-level var.
-          user: ${{ vars.NUGET_TRUSTED_USER }}
+          # nuget.org user that created the trust policy (shared service account). Hardcoded because
+          # private repos can't read org-level Actions variables in the current plan.
+          user: virto
 
       - name: Publish Nuget
         if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.42
+# https://virtocommerce.atlassian.net/browse/VCST-5373
 name: Module CI
 
 on:
@@ -368,7 +368,7 @@ jobs:
         ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request'))) }}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.40
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.42
     with:
       installModules: 'false'
       installCustomModule: 'true'
@@ -425,7 +425,7 @@ jobs:
     permissions:
       contents: read
       deployments: write
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.40
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.42
     with:
       releaseSource: module
       moduleId: ${{ needs.ci.outputs.moduleId }}
@@ -433,4 +433,4 @@ jobs:
       moduleBlob: ${{ needs.ci.outputs.blobId }}
       jiraKeys: ${{ needs.ci.outputs.jira-keys }}
       matrix: '{"include":${{ needs.ci.outputs.matrix }}}'
-    secrets: inherit # zizmor: ignore[secrets-inherit] deploy-cloud.yml@v3.800.40 reads undeclared org secrets; explicit passing needs a new release + tag bump
+    secrets: inherit # zizmor: ignore[secrets-inherit] deploy-cloud.yml@v3.800.42 reads undeclared org secrets; explicit passing needs a new release + tag bump

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -85,16 +85,17 @@ jobs:
         github.event.pull_request.head.repo.full_name == '') }}  # Skip version-only bumps; PR not from a fork or Dependabot
     runs-on: ubuntu-24.04
     # Default GITHUB_TOKEN creates the release + updates the PR; rest uses the REPO_TOKEN PAT.
+    # id-token: write lets NuGet/login mint a short-lived OIDC key (Trusted Publishing).
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     env:
       CLOUD_INSTANCE_BASE_URL: ${{secrets.CLOUD_INSTANCE_BASE_URL}}
       CLIENT_ID: ${{secrets.CLIENT_ID}}
       CLIENT_SECRET: ${{secrets.CLIENT_SECRET}}
       SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
       GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
-      NUGET_KEY: ${{ secrets.NUGET_KEY }}
       BLOB_SAS: ${{ secrets.BLOB_TOKEN }}
       VERSION_SUFFIX: ''
       BUILD_STATE: 'failed'
@@ -198,9 +199,20 @@ jobs:
       - name: Packaging
         run: vc-build Compress -skip Clean+Restore+Compile+Test
 
+      # Trusted Publishing: swap the GitHub OIDC token for a ~1h nuget.org key, minted right before push.
+      - name: NuGet login (OIDC -> temp API key)
+        if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
+        id: nuget_login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          # nuget.org user that created the trust policy (shared service account); org-level var.
+          user: ${{ vars.NUGET_TRUSTED_USER }}
+
       - name: Publish Nuget
         if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
         uses: VirtoCommerce/vc-github-actions/publish-nuget@master
+        env:
+          NUGET_KEY: ${{ steps.nuget_login.outputs.NUGET_API_KEY }}
 
       - name: Publish to Blob
         if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master') || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main') }}

--- a/workflow-templates/module-deploy.yml
+++ b/workflow-templates/module-deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.42
+# https://virtocommerce.atlassian.net/browse/VCST-5373
 name: Module deployment
 on:
   workflow_dispatch:

--- a/workflow-templates/module-release-hotfix.yml
+++ b/workflow-templates/module-release-hotfix.yml
@@ -11,7 +11,7 @@ on:
         default: true
         type: boolean
 
-# Least-privilege default; publish-github-release overrides below.
+# Least-privilege default; jobs override below where they need more.
 permissions:
   contents: read
 
@@ -22,7 +22,7 @@ jobs:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.40    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.40
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -48,23 +48,76 @@ jobs:
       id: changelog
       uses: VirtoCommerce/vc-github-actions/changelog-generator@master
 
+  # Trusted Publishing: mint the OIDC key and push in ONE job. A short-lived key can't cross
+  # job boundaries (GitHub redacts masked values from job outputs), and the push can't move
+  # into the cross-repo publish-github.yml (its job_workflow_ref wouldn't match this repo's
+  # policy — NuGet/login issues #6/#9). job_workflow_ref here is module-release-hotfix.yml, which matches.
+  publish-nuget:
+    needs: [build, test]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+    steps:
+      - name: Install VirtoCommerce.GlobalTool
+        uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Reuse the package built by the `build` job (same cache key/path it wrote).
+      - name: Get package from cache
+        id: restore-build
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: ${{ needs.build.outputs.packageFullKey }}
+          path: |
+            ${{ github.workspace }}/artifacts
+            ${{ github.workspace }}/publish
+
+      - name: Exit if cache not restored
+        if: steps.restore-build.outputs.cache-hit != 'true'
+        env:
+          FULL_KEY: ${{ needs.build.outputs.packageFullKey }}
+        run: |
+          echo "::error::Package cache not found for key ${FULL_KEY}"
+          exit 1
+
+      - name: NuGet login (OIDC -> temp API key)
+        id: nuget_login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          # nuget.org user that created the trust policy (shared service account); org-level var.
+          user: ${{ vars.NUGET_TRUSTED_USER }}
+
+      - name: Publish Nuget
+        uses: VirtoCommerce/vc-github-actions/publish-nuget@master
+        with:
+          skipString: 'Clean+Restore+Compile+Test+Pack'
+        env:
+          NUGET_KEY: ${{ steps.nuget_login.outputs.NUGET_API_KEY }}
+
+  # GitHub release only. forceNuget: false — the push is done by publish-nuget above.
+  # publish-github.yml creates the release + edits the PR via the passed GITHUB_TOKEN — grant write to both.
   publish-github-release:
-    # publish-github.yml creates the release + edits the PR via the passed GITHUB_TOKEN — grant write to both.
     permissions:
       contents: write
       pull-requests: write
     needs:
-      [build, test, get-metadata]
+      [build, test, get-metadata, publish-nuget]
     uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.40
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'
       incrementPatch: ${{ github.event.inputs.incrementPatch }}
+      forceNuget: false
       makeLatest: 'false'
 
     secrets:
       envPAT: ${{ secrets.GITHUB_TOKEN }}
-      nugetKey: ${{ secrets.NUGET_KEY }}
 
   increment-version:
     needs:

--- a/workflow-templates/module-release-hotfix.yml
+++ b/workflow-templates/module-release-hotfix.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.42
+# https://virtocommerce.atlassian.net/browse/VCST-5373
 name: Release hotfix
 
 on:
@@ -17,12 +17,12 @@ permissions:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.40
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.42
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.40
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.42
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -111,7 +111,7 @@ jobs:
       pull-requests: write
     needs:
       [build, test, get-metadata, publish-nuget]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.40
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.42
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/workflow-templates/module-release-hotfix.yml
+++ b/workflow-templates/module-release-hotfix.yml
@@ -52,8 +52,10 @@ jobs:
   # job boundaries (GitHub redacts masked values from job outputs), and the push can't move
   # into the cross-repo publish-github.yml (its job_workflow_ref wouldn't match this repo's
   # policy — NuGet/login issues #6/#9). job_workflow_ref here is module-release-hotfix.yml, which matches.
+  # needs get-metadata too: a metadata failure must block the push, else the package publishes while
+  # publish-github-release (which needs get-metadata) is skipped — package with no GitHub release.
   publish-nuget:
-    needs: [build, test]
+    needs: [build, test, get-metadata]
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/workflow-templates/module-release-hotfix.yml
+++ b/workflow-templates/module-release-hotfix.yml
@@ -90,8 +90,9 @@ jobs:
         id: nuget_login
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         with:
-          # nuget.org user that created the trust policy (shared service account); org-level var.
-          user: ${{ vars.NUGET_TRUSTED_USER }}
+          # nuget.org user that created the trust policy (shared service account). Hardcoded because
+          # private repos can't read org-level Actions variables in the current plan.
+          user: virto
 
       - name: Publish Nuget
         uses: VirtoCommerce/vc-github-actions/publish-nuget@master

--- a/workflow-templates/publish-nugets.yml
+++ b/workflow-templates/publish-nugets.yml
@@ -11,18 +11,18 @@ on:
         default: true
         type: boolean
 
-# Least-privilege default; publish-nuget overrides below.
+# Least-privilege default; jobs override below where they need more.
 permissions:
   contents: read
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.40    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.40
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.40    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.40
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -30,19 +30,71 @@ jobs:
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}
 
+  # Trusted Publishing: mint the OIDC key and push in ONE job. A short-lived key can't cross
+  # job boundaries (GitHub redacts masked values from job outputs), and the push can't move
+  # into the cross-repo publish-github.yml (its job_workflow_ref wouldn't match this repo's
+  # policy — NuGet/login issues #6/#9). job_workflow_ref here is publish-nugets.yml, which matches.
   publish-nuget:
-    # publish-github.yml creates the release + edits the PR via the passed GITHUB_TOKEN — grant write to both.
+    needs: [build, test]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+    steps:
+      - name: Install VirtoCommerce.GlobalTool
+        uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Reuse the package built by the `build` job (same cache key/path it wrote).
+      - name: Get package from cache
+        id: restore-build
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: ${{ needs.build.outputs.packageFullKey }}
+          path: |
+            ${{ github.workspace }}/artifacts
+            ${{ github.workspace }}/publish
+
+      - name: Exit if cache not restored
+        if: steps.restore-build.outputs.cache-hit != 'true'
+        env:
+          FULL_KEY: ${{ needs.build.outputs.packageFullKey }}
+        run: |
+          echo "::error::Package cache not found for key ${FULL_KEY}"
+          exit 1
+
+      - name: NuGet login (OIDC -> temp API key)
+        id: nuget_login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          # nuget.org user that created the trust policy (shared service account); org-level var.
+          user: ${{ vars.NUGET_TRUSTED_USER }}
+
+      - name: Publish Nuget
+        uses: VirtoCommerce/vc-github-actions/publish-nuget@master
+        with:
+          skipString: 'Clean+Restore+Compile+Test+Pack'
+        env:
+          NUGET_KEY: ${{ steps.nuget_login.outputs.NUGET_API_KEY }}
+
+  # Blob upload + PR-body link. forceNuget: false — the push is done by publish-nuget above.
+  # publish-github.yml edits the PR via the passed GITHUB_TOKEN — grant write to both.
+  publish-blob:
+    needs: [build, test, publish-nuget]
     permissions:
       contents: write
       pull-requests: write
-    needs:
-      [build, test]
     uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.40
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false
+      forceNuget: false
       forceBlob: true
     secrets:
       envPAT: ${{ secrets.GITHUB_TOKEN }}
-      nugetKey: ${{ secrets.NUGET_KEY }}
       BLOB_TOKEN: ${{ secrets.BLOB_TOKEN }}

--- a/workflow-templates/publish-nugets.yml
+++ b/workflow-templates/publish-nugets.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.42
+# https://virtocommerce.atlassian.net/browse/VCST-5373
 name: Publish nuget
 
 on:
@@ -17,12 +17,12 @@ permissions:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.40
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.42
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.40
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.42
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -90,7 +90,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.40
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.42
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/workflow-templates/publish-nugets.yml
+++ b/workflow-templates/publish-nugets.yml
@@ -72,8 +72,9 @@ jobs:
         id: nuget_login
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         with:
-          # nuget.org user that created the trust policy (shared service account); org-level var.
-          user: ${{ vars.NUGET_TRUSTED_USER }}
+          # nuget.org user that created the trust policy (shared service account). Hardcoded because
+          # private repos can't read org-level Actions variables in the current plan.
+          user: virto
 
       - name: Publish Nuget
         uses: VirtoCommerce/vc-github-actions/publish-nuget@master

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.42
+# https://virtocommerce.atlassian.net/browse/VCST-5373
 name: Release
 
 on:
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.40    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.42    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
VCST-5373: Use NuGet Trusted Publishing

Replaces the long-lived NUGET_KEY secret with GitHub OIDC → nuget.org Trusted Publishing across the module publishing workflows.

Workflow templates — each mints a short-lived nuget.org key via NuGet/login (OIDC) and pushes in the same job, since a masked key can't be passed between jobs (GitHub redacts secrets from job outputs) and can't be minted inside the cross-repo publish-github.yml (job_workflow_ref wouldn't match the trust policy — NuGet/login #6/#9):

module-ci.yml — login + push in the ci job.
publish-nugets.yml — new publish-nuget job (restore cache → login → push); publish-github.yml now called with forceNuget: false for blob only.
module-release-hotfix.yml — same; publish-github.yml does the GitHub release only.
publish-github.yml — consumes the caller-supplied nugetKey; added a guard comment against adding NuGet/login here.

Trusted Publishing policies — nuget.org has no API for policy management (interactive MFA login only), so added scripts/nuget-trusted-publishers/ (Node, no deps): prompts for a session cookie and creates the 3 policies (module-ci.yml, publish-nugets.yml, module-release-hotfix.yml, Environment blank) per repo. create-module-repository.yml now prints the exact command to run after a new repo is created.

Follow-up: the long-lived NUGET_KEY secret can be removed from module repos/org once every repo has policies. Requires org var NUGET_TRUSTED_USER.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> NuGet publishes will fail on any module repo missing the three trust policies or misconfigured OIDC; rollout depends on manual policy setup and redeploying workflow templates to all modules.
> 
> **Overview**
> **Replaces long-lived `NUGET_KEY` with GitHub OIDC → nuget.org Trusted Publishing** for module package pushes (VCST-5373), bundled as shared workflow release **v3.800.42**.
> 
> Module templates **`module-ci.yml`**, **`publish-nugets.yml`**, and **`module-release-hotfix.yml`** now grant `id-token: write`, run **`NuGet/login`** in the **same job** as `publish-nuget`, and pass the short-lived `NUGET_API_KEY` via env. **`publish-nugets`** / **hotfix** split NuGet push into a dedicated job (restore build cache → login → push) and call **`publish-github.yml`** with **`forceNuget: false`** for GitHub release and/or blob only. **`publish-github.yml`** documents why OIDC must not be added there (reusable workflow `job_workflow_ref` would not match per-repo trust policies).
> 
> Adds **`scripts/nuget-trusted-publishers/`** (Node script + README) to create the three nuget.org policies per repo manually (no nuget API). **`create-module-repository.yml`** appends the run summary with the exact command operators must run after a new module repo is created.
> 
> Also registers **`vc-module-sanity`** and **`vc-module-shopify-taxonomy`** in **`deploy-module-workflows.yml`**, bumps reusable workflow pin references to **v3.800.42**, and adds **`node_modules/`** to **`.gitignore`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f324cd408db42946606ef9c9ef2ca637f0346aee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->