### PR TITLE
VCST-5439: Improve output for docker-image-vulnerability-process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.41
+# https://virtocommerce.atlassian.net/browse/VCST-5439
 name: VC build
 
 on:

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.41
+# https://virtocommerce.atlassian.net/browse/VCST-5439
 name: VC cloud deployment
 
 on:

--- a/.github/workflows/deploy-module-workflows.yml
+++ b/.github/workflows/deploy-module-workflows.yml
@@ -7,7 +7,7 @@ on:
         description: 'Version to deploy'
         required: true
         type: string
-        default: 'v3.800.40'
+        default: 'v3.800.41'
 
 # Least privilege: pushes use the REPO_TOKEN PAT, so GITHUB_TOKEN needs only read.
 permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.41
+# https://virtocommerce.atlassian.net/browse/VCST-5439
 name: VC deployment
 
 on:

--- a/.github/workflows/docker-image-vulnerability-process.yml
+++ b/.github/workflows/docker-image-vulnerability-process.yml
@@ -133,138 +133,204 @@ jobs:
           $jiraUser = $env:JIRA_USER
           $jiraToken = $env:JIRA_TOKEN
           $jiraProject = "$env:INPUTS_JIRAPROJECT"
-          $notSkippedVulnerabilities = @()
-          $skippedVulnerabilities = @()
           if ("$env:INPUTS_VULNERABILITYSKIPLIST" -ne '') {
-            $vulnerabilitySkipList = $("$env:INPUTS_VULNERABILITYSKIPLIST".Split(','))
+            $vulnerabilitySkipList = $("$env:INPUTS_VULNERABILITYSKIPLIST".Split(',')) | ForEach-Object { $_.Trim() }
           }
           else {
             $vulnerabilitySkipList = @()
           }
           $assigneeAccountId = "$env:INPUTS_ASSIGNEEACCOUNTID"
           $assigneeEmailAddress = "$env:INPUTS_ASSIGNEEEMAILADDRESS"
+          $failOnFound = ("$env:INPUTS_EXITCODEONFOUNDVULNERABILITIES" -ne '0')
           $jsonContent = get-content "./$env:INPUTS_IMAGETAG.json" -Raw | ConvertFrom-Json
-          $vulnerabilities = @()
-          if ($null -ne $jsonContent -and $null -ne $jsonContent.Results -and $null -ne $jsonContent.Results.Vulnerabilities) {
-            $vulnerabilities = $jsonContent.Results.Vulnerabilities | Where-Object { $null -ne $_.VulnerabilityID }
+
+          # Flatten Trivy results into (vulnerability, target) pairs so we can report WHERE
+          # each CVE was found - every affected module/deps.json - to help remediation.
+          $occurrences = [System.Collections.Generic.List[object]]::new()
+          if ($null -ne $jsonContent -and $null -ne $jsonContent.Results) {
+            foreach ($result in $jsonContent.Results) {
+              if ($null -eq $result.Vulnerabilities) { continue }
+              foreach ($vuln in $result.Vulnerabilities) {
+                if ($null -eq $vuln.VulnerabilityID) { continue }
+                $occurrences.Add([PSCustomObject]@{ Vuln = $vuln; Target = $result.Target })
+              }
+            }
           }
-          if ($null -eq $vulnerabilities -or $vulnerabilities.Count -eq 0) {
-            Write-Host "No '$env:INPUTS_TRIVYSEVERITY' level vulnerabilities found in the image '${env:INPUTS_IMAGEREF}:${env:INPUTS_IMAGETAG}'"
+
+          # Deduplicate by VulnerabilityID (the same CVE repeats across many image targets),
+          # collecting the distinct locations for each CVE.
+          $sevOrder = @{ 'CRITICAL' = 0; 'HIGH' = 1; 'MEDIUM' = 2; 'LOW' = 3; 'UNKNOWN' = 4 }
+          $uniqueVulnerabilities = @($occurrences |
+            Group-Object { $_.Vuln.VulnerabilityID } |
+            ForEach-Object {
+              $v = $_.Group[0].Vuln
+              $locations = @($_.Group | ForEach-Object { $_.Target } | Sort-Object -Unique)
+              [PSCustomObject]@{
+                ID        = $v.VulnerabilityID
+                Severity  = $v.Severity
+                Package   = $v.PkgName
+                Installed = $v.InstalledVersion
+                Fixed     = $v.FixedVersion
+                Url       = $v.PrimaryURL
+                Skipped   = ($vulnerabilitySkipList -contains $v.VulnerabilityID)
+                Locations = $locations
+                Ticket    = ''
+                Raw       = $v
+              }
+            } |
+            Sort-Object @{ Expression = { $sevOrder[$_.Severity] } }, @{ Expression = { [int]$_.Skipped } }, ID)
+
+          $blocking = @($uniqueVulnerabilities | Where-Object { -not $_.Skipped })
+          $ignored = @($uniqueVulnerabilities | Where-Object { $_.Skipped })
+
+          # Renders the scan summary to the run Summary page and mirrors it to the step log.
+          # Defined as a function so it can be published before every exit - including a Jira
+          # failure midway - and always reflect the latest ticket state.
+          function Publish-ScanSummary {
+            $lines = [System.Collections.Generic.List[string]]::new()
+            $lines.Add("## 🛡️ Trivy scan summary")
+            $lines.Add("")
+            $lines.Add("**Image:** ``${env:INPUTS_IMAGEREF}:${env:INPUTS_IMAGETAG}``  ")
+            $lines.Add("**Severities scanned:** ``$env:INPUTS_TRIVYSEVERITY``  ")
+            $lines.Add("")
+            if ($uniqueVulnerabilities.Count -eq 0) {
+              $lines.Add("✅ **No vulnerabilities found.**")
+              if ($env:GITHUB_STEP_SUMMARY) { Set-Content -Path $env:GITHUB_STEP_SUMMARY -Value ($lines -join "`n") }
+              return
+            }
+            $lines.Add("**Total unique:** $($uniqueVulnerabilities.Count) &nbsp;|&nbsp; **Blocking:** $($blocking.Count) &nbsp;|&nbsp; **Ignored (skip list):** $($ignored.Count)")
+            $lines.Add("")
+            $lines.Add("| CVE / Advisory | Severity | Package | Installed | Fix | Status | Jira ticket |")
+            $lines.Add("| --- | --- | --- | --- | --- | --- | --- |")
+            foreach ($u in $uniqueVulnerabilities) {
+              if ($u.Skipped) { $rowStatus = '✅ Ignored (skip list)' }
+              elseif ($failOnFound) { $rowStatus = '❌ Blocks build' }
+              else { $rowStatus = '⚠️ Reported' }
+              $fix = if ([string]::IsNullOrEmpty($u.Fixed)) { '—' } else { $u.Fixed }
+              $link = if ([string]::IsNullOrEmpty($u.Url)) { $u.ID } else { "[$($u.ID)]($($u.Url))" }
+              $ticket = if ([string]::IsNullOrEmpty($u.Ticket)) { '—' } else { $u.Ticket }
+              $lines.Add("| $link | $($u.Severity) | $($u.Package) | $($u.Installed) | $fix | $rowStatus | $ticket |")
+            }
+            $lines.Add("")
+            $lines.Add("### Where each vulnerability was found")
+            foreach ($u in $uniqueVulnerabilities) {
+              $lines.Add("<details><summary>$($u.ID) — $($u.Package) — $($u.Locations.Count) location(s)</summary>")
+              $lines.Add("")
+              foreach ($loc in $u.Locations) { $lines.Add("- ``$loc``") }
+              $lines.Add("</details>")
+              $lines.Add("")
+            }
+            if ($env:GITHUB_STEP_SUMMARY) { Set-Content -Path $env:GITHUB_STEP_SUMMARY -Value ($lines -join "`n") }
+            Write-Host ""
+            Write-Host "Final summary for '${env:INPUTS_IMAGEREF}:${env:INPUTS_IMAGETAG}':"
+            $uniqueVulnerabilities |
+              Select-Object ID, Severity, Package, Installed, Fixed, Skipped,
+                @{ N = 'Locations'; E = { $_.Locations.Count } }, Ticket |
+              Format-Table -AutoSize | Out-String | Write-Host
+          }
+
+          if ($uniqueVulnerabilities.Count -eq 0) {
+            Write-Host "✅ No '$env:INPUTS_TRIVYSEVERITY' level vulnerabilities found in the image '${env:INPUTS_IMAGEREF}:${env:INPUTS_IMAGETAG}'."
+            Publish-ScanSummary
             exit 0
           }
-          ## Create Jira auth header
+
+          # List every finding with its locations up-front so failures are easy to triage.
+          Write-Host "Trivy found $($uniqueVulnerabilities.Count) unique $env:INPUTS_TRIVYSEVERITY vulnerability(ies): $($blocking.Count) blocking, $($ignored.Count) ignored by skip list."
+          foreach ($u in $uniqueVulnerabilities) {
+            if ($u.Skipped) { $tag = 'IGNORED ' } elseif ($failOnFound) { $tag = 'BLOCKING' } else { $tag = 'REPORTED' }
+            $fixText = if ([string]::IsNullOrEmpty($u.Fixed)) { 'no fix' } else { "fix $($u.Fixed)" }
+            Write-Host ""
+            Write-Host "[$tag] $($u.ID) ($($u.Severity)) — $($u.Package) $($u.Installed) → $fixText — found in $($u.Locations.Count) location(s):"
+            foreach ($loc in $u.Locations) { Write-Host "    - $loc" }
+          }
+          ## Jira auth header
           $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("$jiraUser`:$jiraToken"))
           $headers = @{
               "Authorization" = "Basic $base64AuthInfo"
               "Content-Type"  = "application/json"
           }
-          foreach ($vulnerability in $vulnerabilities) {
-            # check for skip list
-            if ($vulnerabilitySkipList -contains $vulnerability.VulnerabilityID) {
-                Write-Host "The vulnerabilityID '$($vulnerability.VulnerabilityID)' is skipped as it presents in the skip list"
-                $skippedVulnerabilities += $($vulnerability.VulnerabilityID)
+
+          # ADF (Atlassian Document Format) node helpers keep the ticket body readable.
+          function New-Text($text) { @{ type = "text"; text = "$text" } }
+          function New-Link($text, $href) { @{ type = "text"; text = "$text"; marks = @(@{ type = "link"; attrs = @{ href = "$href" } }) } }
+
+          # Records the ticket state, publishes the summary, and fails the step.
+          function Stop-WithError($vuln, $label, $message) {
+            Write-Host "❌ $message"
+            $vuln.Ticket = $label
+            Publish-ScanSummary
+            exit 1
+          }
+
+          # Only blocking (non-skipped) CVEs get a Jira ticket - one per CVE (the unique set),
+          # so a single lookup/create per CVE instead of one per image target.
+          Write-Host ""
+          foreach ($u in $blocking) {
+            $jiraKey = "[Vulnerability] $($u.ID)"
+            $searchBody = @{ fields = @("key"); jql = "project = $jiraProject and summary ~ '$jiraKey'"; maxResults = 10 } | ConvertTo-Json -Depth 100
+            try {
+                $issueExists = Invoke-RestMethod -Uri "$jiraBaseUrl/rest/api/3/search/jql" -Headers $headers -Method Post -Body $searchBody
+            }
+            catch {
+                Stop-WithError $u '⚠️ lookup failed' "Failed to check the task $jiraKey. Error: $($_.ErrorDetails.Message)"
+            }
+            if ($issueExists.issues.count -gt 0) {
+                $u.Ticket = ($issueExists.issues.key) -join ', '
+                Write-Host "🔍 $($u.ID): existing Jira task(s) $($u.Ticket). Skipping creation."
                 continue
             }
-            else {
-                $notSkippedVulnerabilities += $($vulnerability.VulnerabilityID)
-                $jiraKey = "[Vulnerability] $($vulnerability.VulnerabilityID)"
-                $body = @{
-                    fields     = @("key")
-                    jql        = "project = $jiraProject and summary ~ '$jiraKey'"
-                    maxResults = 10
-                } | ConvertTo-Json -Depth 100
-                # check for Jira ticket existence
-                try {
-                    $issueExists = Invoke-RestMethod -Uri "$jiraBaseUrl/rest/api/3/search/jql" -Headers $headers -Method Post -Body $body
-                    if ($issueExists.issues.count -gt 0) {
-                        Write-Host "🔍 Found $($issueExists.issues.count) task(s) with summary '$jiraKey'. Skipping creation..."
-                        Write-Host "🔍 Existing task(s) key(s): $($issueExists.issues.key)"
-                        continue
-                    }
-                    else {
-                        Write-Host "✅ The task '$jiraKey' not found. Creating new task..."
+
+            # No existing ticket - create one, listing every affected location to aid fixing.
+            Write-Host "➕ $($u.ID): no existing task found. Creating..."
+            $v = $u.Raw
+            $runUrl = "https://github.com/$($env:GITHUB_REPOSITORY)/actions/runs/$($env:GITHUB_RUN_ID)"
+            $details = "Title:`n    $($v.Title)`nDescription:`n    $($v.Description)`nSeverity:`n    $($v.Severity)`nCweIDs:`n    $($v.CweIDs)`nPublished:`n    $($v.PublishedDate)`nCVE URL:`n    "
+            $locationItems = @($u.Locations | ForEach-Object {
+                @{ type = "listItem"; content = @(@{ type = "paragraph"; content = @(New-Text $_) }) }
+            })
+            $body = @{
+                fields = @{
+                    labels      = @("Vulnerability")
+                    summary     = "$jiraKey"
+                    project     = @{ key = "$jiraProject" }
+                    issuetype   = @{ name = "Task" }
+                    assignee    = @{ accountId = $assigneeAccountId; emailAddress = $assigneeEmailAddress }
+                    description = @{
+                        type    = "doc"
+                        version = 1
+                        content = @(
+                            @{ type = "paragraph"; content = @(
+                                New-Text "*** Automatic vulnerability ticket created from Trivy scanner ***"
+                                New-Link "`nWorkflow run`n" $runUrl
+                                New-Text $details
+                                New-Link "$($v.PrimaryURL)" "$($v.PrimaryURL)"
+                            ) }
+                            @{ type = "paragraph"; content = @(@{ type = "text"; text = "Affected locations ($($u.Locations.Count)):"; marks = @(@{ type = "strong" }) }) }
+                            @{ type = "bulletList"; content = $locationItems }
+                        )
                     }
                 }
-                catch {
-                    Write-Host "❌ Failed to check the task $jiraKey. Error: $($_.ErrorDetails.Message)"
-                    exit 1
-                }
+            } | ConvertTo-Json -Depth 100
+            try {
+                $createdIssue = Invoke-RestMethod -Uri "$jiraBaseUrl/rest/api/3/issue" -Headers $headers -Method Post -Body $body
+                $u.Ticket = "$($createdIssue.key) (new)"
+                Write-Host "✅ $($u.ID): created Jira task $($createdIssue.key) (id $($createdIssue.id))."
+                Start-Sleep -Seconds 3
             }
-            # create missing tickets
-            if ($issueExists.issues.count -eq 0) {
-                try {
-                    $body = @{
-                        fields = @{
-                            labels      = @("Vulnerability")
-                            summary     = "$jiraKey"
-                            project     = @{
-                                key = "$jiraProject"
-                            }
-                            issuetype   = @{ name = "Task" }
-                            assignee    = @{
-                                accountId    = $assigneeAccountId
-                                emailAddress = $assigneeEmailAddress
-                            }
-                            description = @{
-                                type    = "doc"
-                                version = 1
-                                content = @(
-                                    @{
-                                        type    = "paragraph"
-                                        content = @(
-                                            @{
-                                                type = "text"
-                                                text = "*** Automatic vulnerability ticket created from Trivy scanner ***"
-                                            },
-                                            @{
-                                                type    = "text"
-                                                text    = "`nWorkflow run`n"
-                                                "marks" = @(
-                                                    @{
-                                                        type  = "link"
-                                                        attrs = @{
-                                                            href = "https://github.com/$($env:GITHUB_REPOSITORY)/actions/runs/$($env:GITHUB_RUN_ID)"
-                                                        }
-                                                    }
-                                                )
-                                            },
-                                            @{
-                                                type = "text"
-                                                text = "Title:`n    $($vulnerability.Title)`nDescription:`n    $($vulnerability.Description)`nSeverity:`n    $($vulnerability.Severity)`nCweIDs:`n    $($vulnerability.CweIDs)`nPublished:`n    $($vulnerability.PublishedDate)`nCVE URL:`n    "
-                                            },
-                                            @{
-                                                type    = "text"
-                                                text    = "$($vulnerability.PrimaryURL)"
-                                                "marks" = @(
-                                                    @{
-                                                        type  = "link"
-                                                        attrs = @{
-                                                            href = "$($vulnerability.PrimaryURL)"
-                                                        }
-                                                    }
-                                                )
-                                            }
-                                        )
-                                    }
-                                )
-                            }
-                        }
-                    } | ConvertTo-Json -Depth 100
-                    $createdIssue = Invoke-RestMethod -Uri "$jiraBaseUrl/rest/api/3/issue" -Headers $headers -Method Post -Body $body
-                    Write-Host "✅ The task '$($createdIssue.key)' created with id '$($createdIssue.id)'."
-                    Start-Sleep -Seconds 3
-                }
-                catch {
-                    Write-Host "❌ Failed to create the task $jiraKey. Error: $($_.Exception.Message)"
-                    exit 1
-                }
+            catch {
+                Stop-WithError $u '⚠️ create failed' "Failed to create the task $jiraKey. Error: $($_.Exception.Message)"
             }
           }
-          if ($notSkippedVulnerabilities.Count -gt 0) {
-            Write-Host "❌ Found vulnerabilities."
+
+          Publish-ScanSummary
+
+          if ($blocking.Count -gt 0) {
+            Write-Host ""
+            Write-Host "❌ Found $($blocking.Count) blocking vulnerability(ies): $(($blocking.ID) -join ', '). Failing with exit code $env:INPUTS_EXITCODEONFOUNDVULNERABILITIES."
             exit $env:INPUTS_EXITCODEONFOUNDVULNERABILITIES
           }
           else {
-            Write-Host "✅ No vulnerabilities found. Ignored $($skippedVulnerabilities.count) by skip list."
+            Write-Host "✅ No blocking vulnerabilities. Ignored $($ignored.Count) by skip list."
             exit 0
           }

--- a/.github/workflows/docker-image-vulnerability-process.yml
+++ b/.github/workflows/docker-image-vulnerability-process.yml
@@ -68,7 +68,7 @@ on:
 
 jobs:
   scan-and-process:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Scan Docker image from registry
         if: ${{ inputs.trivyMode == 'normal' }}

--- a/.github/workflows/docker-image-vulnerability-process.yml
+++ b/.github/workflows/docker-image-vulnerability-process.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.41
+# https://virtocommerce.atlassian.net/browse/VCST-5439
 name: Docker image vulnerability process
 
 on:

--- a/.github/workflows/docker-image-vulnerability-process.yml
+++ b/.github/workflows/docker-image-vulnerability-process.yml
@@ -68,7 +68,7 @@ on:
 
 jobs:
   scan-and-process:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Scan Docker image from registry
         if: ${{ inputs.trivyMode == 'normal' }}

--- a/.github/workflows/docker-image-vulnerability-process.yml
+++ b/.github/workflows/docker-image-vulnerability-process.yml
@@ -160,10 +160,14 @@ jobs:
           # Deduplicate by VulnerabilityID (the same CVE repeats across many image targets),
           # collecting the distinct locations for each CVE.
           $sevOrder = @{ 'CRITICAL' = 0; 'HIGH' = 1; 'MEDIUM' = 2; 'LOW' = 3; 'UNKNOWN' = 4 }
+          # An unknown/unmapped severity sorts last so it never masquerades as most severe.
+          $sevRank = { param($sev) $r = $sevOrder[$sev]; if ($null -eq $r) { 99 } else { $r } }
           $uniqueVulnerabilities = @($occurrences |
             Group-Object { $_.Vuln.VulnerabilityID } |
             ForEach-Object {
-              $v = $_.Group[0].Vuln
+              # The same CVE can be reported with different severities across targets;
+              # keep the most severe occurrence so the row/status is not understated.
+              $v = ($_.Group | Sort-Object { & $sevRank $_.Vuln.Severity })[0].Vuln
               $locations = @($_.Group | ForEach-Object { $_.Target } | Sort-Object -Unique)
               [PSCustomObject]@{
                 ID        = $v.VulnerabilityID
@@ -178,7 +182,7 @@ jobs:
                 Raw       = $v
               }
             } |
-            Sort-Object @{ Expression = { $sevOrder[$_.Severity] } }, @{ Expression = { [int]$_.Skipped } }, ID)
+            Sort-Object @{ Expression = { & $sevRank $_.Severity } }, @{ Expression = { [int]$_.Skipped } }, ID)
 
           $blocking = @($uniqueVulnerabilities | Where-Object { -not $_.Skipped })
           $ignored = @($uniqueVulnerabilities | Where-Object { $_.Skipped })
@@ -186,6 +190,9 @@ jobs:
           # Renders the scan summary to the run Summary page and mirrors it to the step log.
           # Defined as a function so it can be published before every exit - including a Jira
           # failure midway - and always reflect the latest ticket state.
+          # Escapes a value for a Markdown table cell: a literal '|' would otherwise be
+          # read as a column separator and break the table layout.
+          function Format-Cell($value) { "$value" -replace '\|', '\|' }
           function Publish-ScanSummary {
             $lines = [System.Collections.Generic.List[string]]::new()
             $lines.Add("## 🛡️ Trivy scan summary")
@@ -206,10 +213,10 @@ jobs:
               if ($u.Skipped) { $rowStatus = '✅ Ignored (skip list)' }
               elseif ($failOnFound) { $rowStatus = '❌ Blocks build' }
               else { $rowStatus = '⚠️ Reported' }
-              $fix = if ([string]::IsNullOrEmpty($u.Fixed)) { '—' } else { $u.Fixed }
-              $link = if ([string]::IsNullOrEmpty($u.Url)) { $u.ID } else { "[$($u.ID)]($($u.Url))" }
-              $ticket = if ([string]::IsNullOrEmpty($u.Ticket)) { '—' } else { $u.Ticket }
-              $lines.Add("| $link | $($u.Severity) | $($u.Package) | $($u.Installed) | $fix | $rowStatus | $ticket |")
+              $fix = if ([string]::IsNullOrEmpty($u.Fixed)) { '—' } else { Format-Cell $u.Fixed }
+              $link = if ([string]::IsNullOrEmpty($u.Url)) { Format-Cell $u.ID } else { "[$(Format-Cell $u.ID)]($($u.Url))" }
+              $ticket = if ([string]::IsNullOrEmpty($u.Ticket)) { '—' } else { Format-Cell $u.Ticket }
+              $lines.Add("| $link | $(Format-Cell $u.Severity) | $(Format-Cell $u.Package) | $(Format-Cell $u.Installed) | $fix | $rowStatus | $ticket |")
             }
             $lines.Add("")
             $lines.Add("### Where each vulnerability was found")
@@ -327,7 +334,13 @@ jobs:
 
           if ($blocking.Count -gt 0) {
             Write-Host ""
-            Write-Host "❌ Found $($blocking.Count) blocking vulnerability(ies): $(($blocking.ID) -join ', '). Failing with exit code $env:INPUTS_EXITCODEONFOUNDVULNERABILITIES."
+            $foundList = ($blocking.ID) -join ', '
+            if ($failOnFound) {
+              Write-Host "❌ Found $($blocking.Count) blocking vulnerability(ies): $foundList. Failing with exit code $env:INPUTS_EXITCODEONFOUNDVULNERABILITIES."
+            }
+            else {
+              Write-Host "⚠️ Found $($blocking.Count) vulnerability(ies): $foundList. Reporting only, not failing the build (exit code 0)."
+            }
             exit $env:INPUTS_EXITCODEONFOUNDVULNERABILITIES
           }
           else {

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.41
+# https://virtocommerce.atlassian.net/browse/VCST-5439
 name: VC Publish docker
 
 on:

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.41
+# https://virtocommerce.atlassian.net/browse/VCST-5439
 name: VC Publish Github release and Nuget package
 
 on:

--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.41
+# https://virtocommerce.atlassian.net/browse/VCST-5439
 name: Auto tests
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.41
+# https://virtocommerce.atlassian.net/browse/VCST-5439
 name: Release workflow
 
 on:

--- a/.github/workflows/test-and-sonar.yml
+++ b/.github/workflows/test-and-sonar.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.41
+# https://virtocommerce.atlassian.net/browse/VCST-5439
 name: VC unit test and sonar scan
 
 on:

--- a/deprecated/workflows/e2e-autotests.yml
+++ b/deprecated/workflows/e2e-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.41
+# https://virtocommerce.atlassian.net/browse/VCST-5439
 name: Common E2E tests
 
 on:

--- a/deprecated/workflows/e2e.yml
+++ b/deprecated/workflows/e2e.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.41
+# https://virtocommerce.atlassian.net/browse/VCST-5439
 name: Common katalon tests
 
 on:

--- a/deprecated/workflows/get-metadata.yml
+++ b/deprecated/workflows/get-metadata.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.41
+# https://virtocommerce.atlassian.net/browse/VCST-5439
 name: Get metadata
 
 on:

--- a/deprecated/workflows/increment-version.yml
+++ b/deprecated/workflows/increment-version.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.41
+# https://virtocommerce.atlassian.net/browse/VCST-5439
 name: Increment version
 
 on:

--- a/deprecated/workflows/ui-autotests.yml
+++ b/deprecated/workflows/ui-autotests.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.41
+# https://virtocommerce.atlassian.net/browse/VCST-5439
 name: Common UI tests
 
 on:

--- a/workflow-templates/module-ci.yml
+++ b/workflow-templates/module-ci.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.41
+# https://virtocommerce.atlassian.net/browse/VCST-5439
 name: Module CI
 
 on:
@@ -355,7 +355,7 @@ jobs:
         ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request'))) }}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.40
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.41
     with:
       installModules: 'false'
       installCustomModule: 'true'
@@ -412,7 +412,7 @@ jobs:
     permissions:
       contents: read
       deployments: write
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.40
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.41
     with:
       releaseSource: module
       moduleId: ${{ needs.ci.outputs.moduleId }}
@@ -420,4 +420,4 @@ jobs:
       moduleBlob: ${{ needs.ci.outputs.blobId }}
       jiraKeys: ${{ needs.ci.outputs.jira-keys }}
       matrix: '{"include":${{ needs.ci.outputs.matrix }}}'
-    secrets: inherit # zizmor: ignore[secrets-inherit] deploy-cloud.yml@v3.800.40 reads undeclared org secrets; explicit passing needs a new release + tag bump
+    secrets: inherit # zizmor: ignore[secrets-inherit] deploy-cloud.yml@v3.800.41 reads undeclared org secrets; explicit passing needs a new release + tag bump

--- a/workflow-templates/module-deploy.yml
+++ b/workflow-templates/module-deploy.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.41
+# https://virtocommerce.atlassian.net/browse/VCST-5439
 name: Module deployment
 on:
   workflow_dispatch:

--- a/workflow-templates/module-release-hotfix.yml
+++ b/workflow-templates/module-release-hotfix.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.41
+# https://virtocommerce.atlassian.net/browse/VCST-5439
 name: Release hotfix
 
 on:
@@ -17,12 +17,12 @@ permissions:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.40
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.41
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.40    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.41    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -55,7 +55,7 @@ jobs:
       pull-requests: write
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.40
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.41
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/workflow-templates/publish-nugets.yml
+++ b/workflow-templates/publish-nugets.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.41
+# https://virtocommerce.atlassian.net/browse/VCST-5439
 name: Publish nuget
 
 on:
@@ -17,12 +17,12 @@ permissions:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.40    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.41    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.40    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.41    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -37,7 +37,7 @@ jobs:
       pull-requests: write
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.40
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.41
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -1,5 +1,5 @@
-# v3.800.40
-# https://virtocommerce.atlassian.net/browse/VCST-5305
+# v3.800.41
+# https://virtocommerce.atlassian.net/browse/VCST-5439
 name: Release
 
 on:
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.40    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.41    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes CI gate behavior for Docker scans (deduplication, blocking vs skip list, Jira ticket scope) and Jira API usage; widespread v3.800.41 pin bumps affect many module pipelines once deployed.
> 
> **Overview**
> **docker-image-vulnerability-process** is reworked so Trivy JSON is parsed across all `Results` targets, CVEs are deduplicated by ID (keeping the highest severity and all distinct locations), and findings are split into **blocking** vs **skip-list ignored**.
> 
> The step now writes a **GitHub Actions job summary** (markdown table, per-CVE location details, Jira ticket column), logs a structured triage listing before Jira runs, creates **one Jira task per unique blocking CVE** (with affected locations in ADF), and publishes the summary on success or on Jira lookup/create failure via `Stop-WithError`. Skip-list entries are trimmed; exit behavior distinguishes blocking vs ignored-only outcomes and respects `exitCodeOnFoundVulnerabilities` for report-only mode.
> 
> The vulnerability job runner image changes from **ubuntu-22.04** to **ubuntu-latest**.
> 
> Across the repo, shared workflow metadata and pins move from **v3.800.40** (VCST-5305) to **v3.800.41** (VCST-5439), including `deploy-module-workflows` default version and `workflow-templates` reusable workflow references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68946b20d05506b3a8012d089805a8bce3cc1c27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->